### PR TITLE
Refactor rolodex page navigation

### DIFF
--- a/app/rolodex/rolodex.css
+++ b/app/rolodex/rolodex.css
@@ -178,6 +178,85 @@
   }
 }
 
+.context-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px 20px;
+}
+
+@media (max-width: 768px) {
+  .context-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.rolodex-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.tab-button {
+  padding: 10px 18px;
+  border-radius: 9999px;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  background: transparent;
+  color: var(--text-secondary);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+
+.tab-button:hover,
+.tab-button:focus-visible {
+  background: rgba(37, 99, 235, 0.08);
+  border-color: rgba(37, 99, 235, 0.35);
+  color: var(--text-primary);
+  outline: none;
+}
+
+.tab-button.active {
+  background: rgba(37, 99, 235, 0.16);
+  border-color: rgba(37, 99, 235, 0.45);
+  color: var(--text-primary);
+}
+
+.tab-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.simple-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.view-helper {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.email-form-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 18px 20px;
+}
+
 .field {
   display: flex;
   flex-direction: column;
@@ -460,6 +539,58 @@
   display: flex;
   flex-direction: column;
   gap: 16px;
+}
+
+.table-scroll {
+  border: 1px solid var(--card-border);
+  border-radius: 18px;
+  overflow: hidden;
+  overflow-x: auto;
+  background: rgba(15, 23, 42, 0.02);
+}
+
+.view-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 720px;
+}
+
+.view-table caption {
+  caption-side: top;
+  padding: 12px 16px;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  text-align: left;
+}
+
+.view-table th,
+.view-table td {
+  padding: 12px 16px;
+  text-align: left;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.35);
+  color: var(--text-primary);
+  font-size: 0.9rem;
+}
+
+.view-table thead th {
+  background: rgba(37, 99, 235, 0.08);
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.view-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.view-table a {
+  color: rgba(37, 99, 235, 0.95);
+  text-decoration: none;
+}
+
+.view-table a:hover,
+.view-table a:focus-visible {
+  text-decoration: underline;
+  outline: none;
 }
 
 .inline-result {


### PR DESCRIPTION
## Summary
- convert the rolodex view into tabbed navigation for create, view, update, and email flows while keeping the URL stable
- present contact results in a structured table with sample data on the view tab and streamline the email tab to subject and message inputs
- relax profile URL validation to accept links without an explicit protocol and add styles for the new layout

## Testing
- npm run lint *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68de3abaf1788320a089a1ca7cd2935f