### PR TITLE
Wire Gmail delivery into Rolodex email tab

### DIFF
--- a/app/api/gmail/send/route.ts
+++ b/app/api/gmail/send/route.ts
@@ -1,0 +1,162 @@
+import { NextRequest, NextResponse } from "next/server";
+import crypto from "crypto";
+import { Pool } from "pg";
+
+export const runtime = "nodejs";
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+
+function decrypt(buffer: Buffer) {
+  const key = Buffer.from(process.env.ENCRYPTION_KEY!, "utf8");
+  const iv = buffer.subarray(0, 12);
+  const tag = buffer.subarray(12, 28);
+  const data = buffer.subarray(28);
+  const decipher = crypto.createDecipheriv("aes-256-gcm", key, iv);
+  decipher.setAuthTag(tag);
+  const decrypted = Buffer.concat([decipher.update(data), decipher.final()]);
+  return decrypted.toString("utf8");
+}
+
+function base64UrlEncode(value: string) {
+  return Buffer.from(value, "utf8")
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
+}
+
+async function exchangeRefreshToken(refreshToken: string) {
+  const params = new URLSearchParams({
+    client_id: process.env.GOOGLE_CLIENT_ID!,
+    client_secret: process.env.GOOGLE_CLIENT_SECRET!,
+    grant_type: "refresh_token",
+    refresh_token: refreshToken,
+  });
+
+  const response = await fetch("https://oauth2.googleapis.com/token", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: params,
+  });
+
+  if (!response.ok) {
+    const detail = await response.text();
+    throw new Error(detail || "Failed to refresh Gmail access token.");
+  }
+
+  const json = (await response.json()) as { access_token?: string };
+  if (!json.access_token) {
+    throw new Error("Missing access token from Google response.");
+  }
+
+  return json.access_token;
+}
+
+async function sendMessage(accessToken: string, rawMessage: string) {
+  const response = await fetch(
+    "https://gmail.googleapis.com/gmail/v1/users/me/messages/send",
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ raw: base64UrlEncode(rawMessage) }),
+    }
+  );
+
+  const text = await response.text();
+  let data: unknown = null;
+  try {
+    data = text ? JSON.parse(text) : null;
+  } catch {
+    data = text;
+  }
+
+  if (!response.ok) {
+    const message =
+      (typeof data === "string" && data) ||
+      (data && typeof data === "object" && "error" in data && (data as any).error) ||
+      response.statusText ||
+      "Failed to send Gmail message.";
+    throw new Error(message);
+  }
+
+  return data;
+}
+
+export async function POST(req: NextRequest) {
+  let payload: unknown;
+  try {
+    payload = await req.json();
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+
+  const body = (payload ?? {}) as {
+    username?: string;
+    to?: string;
+    subject?: string;
+    message?: string;
+  };
+
+  const username = typeof body.username === "string" ? body.username.trim() : "";
+  const to = typeof body.to === "string" ? body.to.trim() : "";
+  const subject = typeof body.subject === "string" ? body.subject.trim() : "";
+  const message = typeof body.message === "string" ? body.message : "";
+
+  if (!username) {
+    return NextResponse.json({ error: "missing_username" }, { status: 400 });
+  }
+  if (!to) {
+    return NextResponse.json({ error: "missing_recipient" }, { status: 400 });
+  }
+  if (!message.trim()) {
+    return NextResponse.json({ error: "missing_message" }, { status: 400 });
+  }
+
+  const tokenRow = await pool.query(
+    "select refresh_token_enc, google_email from user_gmail_tokens where user_id = $1",
+    [username]
+  );
+
+  if (tokenRow.rowCount === 0) {
+    return NextResponse.json({ error: "not_connected" }, { status: 404 });
+  }
+
+  const row = tokenRow.rows[0] as {
+    refresh_token_enc: Buffer;
+    google_email: string;
+  };
+  const refreshToken = decrypt(row.refresh_token_enc);
+
+  let accessToken: string;
+  try {
+    accessToken = await exchangeRefreshToken(refreshToken);
+  } catch (error) {
+    const messageText =
+      error instanceof Error ? error.message : "Failed to refresh Gmail access token.";
+    return NextResponse.json({ error: messageText }, { status: 502 });
+  }
+
+  const sender = row.google_email;
+  const lines = [
+    `From: ${sender}`,
+    `To: ${to}`,
+    `Subject: ${subject || ""}`,
+    "MIME-Version: 1.0",
+    "Content-Type: text/plain; charset=\"UTF-8\"",
+    "Content-Transfer-Encoding: 7bit",
+    "",
+    message,
+  ];
+  const raw = lines.join("\r\n");
+
+  try {
+    const gmailResponse = await sendMessage(accessToken, raw);
+    return NextResponse.json({ success: true, gmail: gmailResponse });
+  } catch (error) {
+    const messageText = error instanceof Error ? error.message : "Failed to send Gmail message.";
+    return NextResponse.json({ error: messageText }, { status: 502 });
+  }
+}

--- a/app/api/oauth/google/status/route.ts
+++ b/app/api/oauth/google/status/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from "next/server";
+import { Pool } from "pg";
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+
+export const runtime = "nodejs";
+
+export async function GET(req: NextRequest) {
+  const username = req.nextUrl.searchParams.get("username")?.trim();
+  if (!username) {
+    return NextResponse.json({ error: "missing_username" }, { status: 400 });
+  }
+
+  const result = await pool.query(
+    "select google_email from user_gmail_tokens where user_id = $1",
+    [username]
+  );
+
+  if (result.rowCount === 0) {
+    return NextResponse.json({ error: "not_connected" }, { status: 404 });
+  }
+
+  return NextResponse.json({ email: result.rows[0].google_email });
+}

--- a/app/rolodex/page.js
+++ b/app/rolodex/page.js
@@ -84,6 +84,38 @@ const TOAST_TIMEOUT = 4500;
 
 const EMAIL_REGEX = /.+@.+\..+/;
 
+const TAB_ITEMS = [
+  { id: "create", label: "Create" },
+  { id: "view", label: "View" },
+  { id: "update", label: "Update" },
+  { id: "email", label: "Email" },
+];
+
+const ACTION_LABELS = {
+  create: "Create",
+  view: "View",
+  update: "Update",
+  email: "Send Email",
+};
+
+const LOADING_LABELS = {
+  create: "Creating…",
+  view: "Viewing…",
+  update: "Updating…",
+  email: "Sending…",
+};
+
+const VIEW_COLUMNS = [
+  { key: "local_id", label: "Local ID" },
+  { key: "full_name", label: "Full Name" },
+  { key: "title", label: "Title" },
+  { key: "company", label: "Company" },
+  { key: "location", label: "Location" },
+  { key: "profile_url", label: "Profile URL" },
+  { key: "email", label: "Email" },
+  { key: "last_updated", label: "Last Updated" },
+];
+
 function validateEmail(value) {
   if (!value) {
     return { status: null, message: "" };
@@ -98,10 +130,36 @@ function validateProfileUrl(value) {
   if (!value) {
     return { status: null, message: "" };
   }
-  if (!/^https?:\/\//i.test(value)) {
-    return { status: "error", message: "Add https://" };
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return { status: null, message: "" };
+  }
+  if (/\s/.test(trimmed)) {
+    return { status: "error", message: "Enter a valid URL (https optional)." };
+  }
+  try {
+    // Allow URLs without protocol by defaulting to https during validation.
+    // The constructed URL is only used for validation purposes.
+    const candidate = trimmed.includes("://") ? trimmed : `https://${trimmed}`;
+    new URL(candidate);
+  } catch {
+    return { status: "error", message: "Enter a valid URL (https optional)." };
   }
   return { status: "success", message: "" };
+}
+
+function normalizeProfileHref(value) {
+  if (!value) return "";
+  return /^https?:\/\//i.test(value) ? value : `https://${value}`;
+}
+
+function formatDateTime(value) {
+  if (!value) return "";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return date.toLocaleString();
 }
 
 function formatSummary(record) {
@@ -213,6 +271,7 @@ function IconAlert(props) {
 }
 
 export default function Rolodex() {
+  const [activeTab, setActiveTab] = useState("create");
   const [username, setUsername] = useState("");
   const [contactId, setContactId] = useState("");
   const [fullName, setFullName] = useState("");
@@ -223,11 +282,14 @@ export default function Rolodex() {
   const [profileUrl, setProfileUrl] = useState("");
   const [subject, setSubject] = useState("");
   const [message, setMessage] = useState("");
+  const [lastAction, setLastAction] = useState(null);
   const [response, setResponse] = useState(null);
   const [inlineSummary, setInlineSummary] = useState("");
   const [errorMessage, setErrorMessage] = useState("");
   const [loadingAction, setLoadingAction] = useState(null);
   const [gmailStatus, setGmailStatus] = useState("disconnected");
+  const [gmailUsername, setGmailUsername] = useState("");
+  const [activeContactEmail, setActiveContactEmail] = useState("");
   const [toasts, setToasts] = useState([]);
   const [fieldErrors, setFieldErrors] = useState({ email: "", profileUrl: "" });
   const [fieldStatus, setFieldStatus] = useState({ email: null, profileUrl: null });
@@ -239,8 +301,10 @@ export default function Rolodex() {
 
   const trimmedUsernameForLink = username.trim();
   const oauthUrl = trimmedUsernameForLink
-    ? `/api/oauth/google/start?userId=${encodeURIComponent(trimmedUsernameForLink)}`
-    : "/api/oauth/google/start?userId=YOUR_USER_ID";
+    ? `/api/oauth/google/start?username=${encodeURIComponent(trimmedUsernameForLink)}`
+    : "/api/oauth/google/start?username=YOUR_USER_ID";
+
+  const GMAIL_STORAGE_KEY = "rolodex.gmailUsername";
 
   const pushToast = useCallback((type, message) => {
     const id = Math.random().toString(36).slice(2);
@@ -322,6 +386,11 @@ export default function Rolodex() {
     }
   }, [contactHighlight, contactId]);
 
+  useEffect(() => {
+    setUsernameHighlight(false);
+    setContactHighlight(false);
+  }, [activeTab]);
+
   const handleCopyContactId = useCallback(() => {
     if (!contactId.trim()) {
       return;
@@ -340,16 +409,120 @@ export default function Rolodex() {
       });
   }, [contactId, pushToast]);
 
+  const verifyGmailStatus = useCallback(
+    async (targetUsername, { silent = false, allowDisconnectToast = false } = {}) => {
+      if (!targetUsername) {
+        setGmailStatus("disconnected");
+        return { connected: false };
+      }
+      try {
+        const res = await fetch(
+          `/api/oauth/google/status?username=${encodeURIComponent(targetUsername)}`,
+          { cache: "no-store" }
+        );
+        if (res.status === 404) {
+          if (!silent && allowDisconnectToast) {
+            pushToast("info", "Gmail connection not found. Please reconnect.");
+          }
+          setGmailStatus("disconnected");
+          if (typeof window !== "undefined") {
+            window.localStorage.removeItem(GMAIL_STORAGE_KEY);
+          }
+          return { connected: false };
+        }
+        if (!res.ok) {
+          const message = (await res.text()) || "Unable to verify Gmail status.";
+          throw new Error(message);
+        }
+        const data = await res.json();
+        setGmailStatus("connected");
+        setGmailUsername(targetUsername);
+        if (!silent) {
+          const emailAddress = data?.email;
+          pushToast(
+            "success",
+            emailAddress ? `Gmail connected as ${emailAddress}.` : "Gmail connected."
+          );
+        }
+        if (typeof window !== "undefined") {
+          window.localStorage.setItem(GMAIL_STORAGE_KEY, targetUsername);
+        }
+        return { connected: true, details: data };
+      } catch (error) {
+        setGmailStatus("disconnected");
+        if (!silent) {
+          const message =
+            error instanceof Error ? error.message : "Failed to verify Gmail status.";
+          pushToast("error", message);
+        }
+        return { connected: false, error };
+      }
+    },
+    [GMAIL_STORAGE_KEY, pushToast]
+  );
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const storedUsername = window.localStorage.getItem(GMAIL_STORAGE_KEY);
+    if (storedUsername) {
+      setGmailUsername(storedUsername);
+      verifyGmailStatus(storedUsername, { silent: true }).catch(() => {
+        /* noop */
+      });
+    }
+  }, [GMAIL_STORAGE_KEY, verifyGmailStatus]);
+
+  useEffect(() => {
+    if (!gmailUsername) return;
+    const handleVisibility = () => {
+      if (document.visibilityState === "visible") {
+        verifyGmailStatus(gmailUsername, { silent: true }).catch(() => {
+          /* noop */
+        });
+      }
+    };
+    document.addEventListener("visibilitychange", handleVisibility);
+    return () => document.removeEventListener("visibilitychange", handleVisibility);
+  }, [gmailUsername, verifyGmailStatus]);
+
   const handleGmailClick = useCallback(
     (event) => {
       event.preventDefault();
       if (gmailStatus === "connecting") return;
+      const trimmedUsername = username.trim();
+      if (!trimmedUsername) {
+        pushToast("error", "Enter a username before connecting Gmail.");
+        setUsernameHighlight(true);
+        return;
+      }
+      const width = 520;
+      const height = 640;
+      const left = window.screenX + (window.outerWidth - width) / 2;
+      const top = window.screenY + (window.outerHeight - height) / 2;
+      const features = `width=${width},height=${height},left=${left},top=${top},status=no,toolbar=no,menubar=no`;
+      const popup = window.open(oauthUrl, "rolodex-gmail-oauth", features);
+      if (!popup) {
+        pushToast("error", "Popup blocked. Allow popups to connect Gmail.");
+        return;
+      }
       setGmailStatus("connecting");
-      setTimeout(() => {
-        window.location.href = oauthUrl;
-      }, 120);
+      setGmailUsername(trimmedUsername);
+      if (typeof window !== "undefined") {
+        window.localStorage.setItem(GMAIL_STORAGE_KEY, trimmedUsername);
+      }
+      const timer = window.setInterval(() => {
+        if (popup.closed) {
+          window.clearInterval(timer);
+          verifyGmailStatus(trimmedUsername, {
+            silent: false,
+            allowDisconnectToast: true,
+          }).catch(() => {
+            /* noop */
+          });
+        }
+      }, 600);
     },
-    [gmailStatus, oauthUrl]
+    [GMAIL_STORAGE_KEY, gmailStatus, oauthUrl, pushToast, username, verifyGmailStatus]
   );
 
   const handleSubjectKeyDown = useCallback((event) => {
@@ -376,17 +549,13 @@ export default function Rolodex() {
     setResponse(null);
     setInlineSummary("");
     setErrorMessage("");
+    setLastAction(null);
   }, []);
 
   const handleSubmit = useCallback(
     async (event) => {
       event.preventDefault();
-      const action = event.nativeEvent.submitter?.value;
-      if (!action) {
-        setErrorMessage("Unknown action");
-        pushToast("error", "Unknown action");
-        return;
-      }
+      const action = activeTab;
       setLoadingAction(action);
       resetResponses();
       setUsernameHighlight(false);
@@ -406,15 +575,13 @@ export default function Rolodex() {
         .filter(([, value]) => Boolean(value));
       const contactDetails = Object.fromEntries(contactDetailsEntries);
 
-      if (action === "update" || action === "email") {
-        if (!trimmedContactId) {
-          const message = "Contact ID is required for this action.";
-          setErrorMessage(message);
-          pushToast("error", message);
-          setContactHighlight(true);
-          setLoadingAction(null);
-          return;
-        }
+      if (action === "update" && !trimmedContactId) {
+        const message = "Contact ID is required to update a contact.";
+        setErrorMessage(message);
+        pushToast("error", message);
+        setContactHighlight(true);
+        setLoadingAction(null);
+        return;
       }
 
       if (action === "view" && !trimmedUsernameValue) {
@@ -424,6 +591,38 @@ export default function Rolodex() {
         setUsernameHighlight(true);
         setLoadingAction(null);
         return;
+      }
+
+      if (action === "email") {
+        if (!trimmedUsernameValue) {
+          const messageText = "Username is required to send an email.";
+          setErrorMessage(messageText);
+          pushToast("error", messageText);
+          setUsernameHighlight(true);
+          setLoadingAction(null);
+          return;
+        }
+        if (!trimmedContactId) {
+          const message = "Select a contact before sending an email.";
+          setErrorMessage(message);
+          pushToast("error", message);
+          setLoadingAction(null);
+          return;
+        }
+        if (!activeContactEmail) {
+          const message = "Selected contact is missing an email address.";
+          setErrorMessage(message);
+          pushToast("error", message);
+          setLoadingAction(null);
+          return;
+        }
+        if (gmailStatus !== "connected") {
+          const message = "Connect Gmail before sending an email.";
+          setErrorMessage(message);
+          pushToast("error", message);
+          setLoadingAction(null);
+          return;
+        }
       }
 
       const body = {
@@ -449,11 +648,51 @@ export default function Rolodex() {
           setLoadingAction(null);
           return;
         }
-        if (trimmedSubject) {
-          body.subject = trimmedSubject;
+        setLastAction(action);
+
+        const emailPayload = {
+          username: trimmedUsernameValue,
+          to: activeContactEmail,
+          message: trimmedMessage,
+          ...(trimmedSubject ? { subject: trimmedSubject } : {}),
+          contactId: trimmedContactId,
+        };
+        try {
+          const r = await fetch("/api/gmail/send", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(emailPayload),
+          });
+          const text = await r.text();
+          let data;
+          try {
+            data = text ? JSON.parse(text) : null;
+          } catch {
+            data = text;
+          }
+          if (!r.ok) {
+            const messageText =
+              (typeof data === "string" && data) ||
+              (data && typeof data === "object" && "error" in data && data.error) ||
+              r.statusText ||
+              "Email send failed";
+            throw new Error(messageText);
+          }
+          setResponse(data ?? { success: true });
+          pushToast("success", "Email sent with Gmail.");
+          setInlineSummary((prev) => prev || "Email delivered.");
+        } catch (error) {
+          const messageText = error instanceof Error ? error.message : "Email send failed";
+          setErrorMessage(messageText);
+          pushToast("error", messageText);
+          setResponse(null);
+        } finally {
+          setLoadingAction(null);
         }
-        body.message = trimmedMessage;
+        return;
       }
+
+      setLastAction(action);
 
       try {
         const r = await fetch("/api/rolodex", {
@@ -481,13 +720,20 @@ export default function Rolodex() {
           pushToast("success", "Contact created.");
         } else if (action === "update") {
           pushToast("success", "Contact updated.");
-        } else if (action === "email") {
-          pushToast("success", "Email sent.");
         } else if (action === "view") {
           if (!data || (Array.isArray(data) && data.length === 0)) {
             pushToast("info", "0 results found.");
+            setActiveContactEmail("");
           } else {
             const record = Array.isArray(data) ? data[0] : data;
+            if (record && record.local_id != null) {
+              setContactId(String(record.local_id));
+            }
+            if (record && typeof record.email === "string") {
+              setActiveContactEmail(record.email);
+            } else {
+              setActiveContactEmail("");
+            }
             setInlineSummary(formatSummary(record));
             pushToast("success", "Contact loaded.");
           }
@@ -502,9 +748,12 @@ export default function Rolodex() {
       }
     },
     [
+      activeContactEmail,
+      activeTab,
       contactId,
       email,
       fullName,
+      gmailStatus,
       location,
       message,
       profileUrl,
@@ -522,16 +771,47 @@ export default function Rolodex() {
     return "Connect Gmail";
   }, [gmailStatus]);
 
-  useEffect(() => {
-    const handleVisibility = () => {
-      if (document.visibilityState === "visible" && gmailStatus === "connecting") {
-        setGmailStatus("connected");
-        pushToast("success", "Gmail connected.");
-      }
-    };
-    document.addEventListener("visibilitychange", handleVisibility);
-    return () => document.removeEventListener("visibilitychange", handleVisibility);
-  }, [gmailStatus, pushToast]);
+  const usernameHelperText = useMemo(() => {
+    if (activeTab === "view") {
+      return "Enter a username to load contacts.";
+    }
+    if (activeTab === "update") {
+      return "Use with Contact ID to update an existing contact.";
+    }
+    if (activeTab === "create") {
+      return "Optional: associate the contact with a user.";
+    }
+    return contactId.trim()
+      ? `Email will be sent to contact #${contactId}.`
+      : "View a contact first to load their details.";
+  }, [activeTab, contactId]);
+
+  const contactHelperText = useMemo(() => {
+    if (activeTab === "update") {
+      return "Required to update an existing contact.";
+    }
+    if (activeTab === "create") {
+      return "Optional unless you are updating a specific record.";
+    }
+    return "Loaded from the selected contact.";
+  }, [activeTab]);
+
+  const buttonClassName = useMemo(() => {
+    if (activeTab === "create") return "button";
+    if (activeTab === "email") return "button ghost";
+    return "button secondary";
+  }, [activeTab]);
+
+  const isLoading = loadingAction === activeTab;
+  const submitLabel = isLoading ? LOADING_LABELS[activeTab] : ACTION_LABELS[activeTab];
+
+  const viewRecords = useMemo(() => {
+    if (lastAction !== "view" || !response) {
+      return [];
+    }
+    const records = Array.isArray(response) ? response : [response];
+    return records.filter((record) => record && typeof record === "object");
+  }, [lastAction, response]);
 
   return (
     <div className="rolodex-page">
@@ -563,245 +843,272 @@ export default function Rolodex() {
           </button>
         </header>
 
+        <nav className="tab-list" role="tablist" aria-label="Rolodex actions">
+          {TAB_ITEMS.map((tab) => {
+            const isActive = activeTab === tab.id;
+            return (
+              <button
+                key={tab.id}
+                type="button"
+                role="tab"
+                aria-selected={isActive}
+                className={`tab-button${isActive ? " active" : ""}`}
+                onClick={() => setActiveTab(tab.id)}
+                disabled={Boolean(loadingAction) && tab.id !== activeTab}
+              >
+                {tab.label}
+              </button>
+            );
+          })}
+        </nav>
+
         <form className="rolodex-form" onSubmit={handleSubmit} noValidate>
-          <div className="rolodex-form-grid">
-            <div className={`field${usernameHighlight ? " error" : ""}`}>
-              <label className="field-label" htmlFor="username">
-                Username
-              </label>
-              <input
-                id="username"
-                className="text-input"
-                value={username}
-                onChange={(event) => setUsername(event.target.value)}
-                placeholder="Username"
-                autoComplete="off"
-              />
-              <div className={`helper-text${usernameHighlight ? " error" : ""}`}>
-                {usernameHighlight
-                  ? "Username is required to view a contact."
-                  : "Use both to update an existing contact."}
+          {(activeTab === "create" || activeTab === "update") && (
+            <div className="rolodex-form-grid">
+              <div className={`field${usernameHighlight ? " error" : ""}`}>
+                <label className="field-label" htmlFor="username">
+                  Username
+                </label>
+                <input
+                  id="username"
+                  className="text-input"
+                  value={username}
+                  onChange={(event) => setUsername(event.target.value)}
+                  placeholder="Username"
+                  autoComplete="off"
+                />
+                <div className={`helper-text${usernameHighlight ? " error" : ""}`}>
+                  {usernameHighlight
+                    ? "Username is required to view a contact."
+                    : usernameHelperText}
+                </div>
+              </div>
+
+              <div className={`field${contactHighlight ? " error" : ""}`}>
+                <label className="field-label" htmlFor="contactId">
+                  Contact ID
+                </label>
+                <input
+                  id="contactId"
+                  className="text-input"
+                  value={contactId}
+                  onChange={(event) => {
+                    setContactId(event.target.value);
+                    setActiveContactEmail("");
+                  }}
+                  placeholder="Contact ID"
+                  autoComplete="off"
+                />
+                {contactId.trim() && (
+                  <button
+                    type="button"
+                    className="copy-button"
+                    onClick={handleCopyContactId}
+                    aria-label="Copy contact ID"
+                  >
+                    <IconCopy />
+                  </button>
+                )}
+                <div className={`helper-text${contactHighlight ? " error" : ""}`}>
+                  {contactHighlight
+                    ? "Contact ID is required to update a contact."
+                    : contactHelperText}
+                </div>
+              </div>
+
+              <div className="field">
+                <label className="field-label" htmlFor="fullName">
+                  Full Name
+                </label>
+                <input
+                  id="fullName"
+                  className="text-input"
+                  value={fullName}
+                  onChange={(event) => setFullName(event.target.value)}
+                  placeholder="Full Name"
+                />
+                <div className="helper-text" />
+              </div>
+
+              <div className="field">
+                <label className="field-label" htmlFor="title">
+                  Title
+                </label>
+                <input
+                  id="title"
+                  className="text-input"
+                  value={title}
+                  onChange={(event) => setTitle(event.target.value)}
+                  placeholder="Title"
+                />
+                <div className="helper-text" />
+              </div>
+
+              <div className="field">
+                <label className="field-label" htmlFor="company">
+                  Company
+                </label>
+                <input
+                  id="company"
+                  className="text-input"
+                  value={company}
+                  onChange={(event) => setCompany(event.target.value)}
+                  placeholder="Company"
+                />
+                <div className="helper-text" />
+              </div>
+
+              <div className="field">
+                <label className="field-label" htmlFor="location">
+                  Location
+                </label>
+                <input
+                  id="location"
+                  className="text-input"
+                  value={location}
+                  onChange={(event) => setLocation(event.target.value)}
+                  placeholder="Location"
+                />
+                <div className="helper-text" />
+              </div>
+
+              <div
+                className={`field${
+                  fieldStatus.email === "error"
+                    ? " error"
+                    : fieldStatus.email === "success"
+                    ? " success"
+                    : ""
+                }`}
+              >
+                <label className="field-label" htmlFor="email">
+                  Email
+                </label>
+                <input
+                  id="email"
+                  className="text-input"
+                  value={email}
+                  onChange={(event) => setEmail(event.target.value)}
+                  onBlur={(event) => handleBlur("email", event.target.value)}
+                  onKeyDown={handleEmailKeyDown}
+                  placeholder="Email"
+                  inputMode="email"
+                  autoComplete="email"
+                />
+                <span className="success-indicator">
+                  <IconCheck />
+                </span>
+                <div className={`validation-text${fieldErrors.email ? " error" : ""}`}>
+                  {fieldErrors.email}
+                </div>
+              </div>
+
+              <div
+                className={`field${
+                  fieldStatus.profileUrl === "error"
+                    ? " error"
+                    : fieldStatus.profileUrl === "success"
+                    ? " success"
+                    : ""
+                }`}
+              >
+                <label className="field-label" htmlFor="profileUrl">
+                  Profile URL
+                </label>
+                <input
+                  id="profileUrl"
+                  className="text-input"
+                  value={profileUrl}
+                  onChange={(event) => setProfileUrl(event.target.value)}
+                  onBlur={(event) => handleBlur("profileUrl", event.target.value)}
+                  placeholder="Profile URL (e.g., linkedin.com/abc)"
+                  inputMode="url"
+                />
+                <span className="success-indicator">
+                  <IconCheck />
+                </span>
+                <div className={`validation-text${fieldErrors.profileUrl ? " error" : ""}`}>
+                  {fieldErrors.profileUrl}
+                </div>
               </div>
             </div>
+          )}
 
-            <div className={`field${contactHighlight ? " error" : ""}`}>
-              <label className="field-label" htmlFor="contactId">
-                Contact ID
-              </label>
-              <input
-                id="contactId"
-                className="text-input"
-                value={contactId}
-                onChange={(event) => setContactId(event.target.value)}
-                placeholder="Contact ID"
-                autoComplete="off"
-              />
-              {contactId.trim() && (
-                <button
-                  type="button"
-                  className="copy-button"
-                  onClick={handleCopyContactId}
-                  aria-label="Copy contact ID"
-                >
-                  <IconCopy />
-                </button>
-              )}
-              <div className={`helper-text${contactHighlight ? " error" : ""}`}>
-                {contactHighlight
-                  ? "Contact ID is required for this action."
-                  : "Use both to update an existing contact."}
+          {activeTab === "view" && (
+            <div className="rolodex-form-grid single">
+              <div className={`field${usernameHighlight ? " error" : ""}`}>
+                <label className="field-label" htmlFor="username">
+                  Username
+                </label>
+                <input
+                  id="username"
+                  className="text-input"
+                  value={username}
+                  onChange={(event) => setUsername(event.target.value)}
+                  placeholder="Username"
+                  autoComplete="off"
+                />
+                <div className={`helper-text${usernameHighlight ? " error" : ""}`}>
+                  {usernameHighlight
+                    ? "Username is required to view a contact."
+                    : usernameHelperText}
+                </div>
               </div>
             </div>
+          )}
 
-            <div className="field">
-              <label className="field-label" htmlFor="fullName">
-                Full Name
-              </label>
-              <input
-                id="fullName"
-                className="text-input"
-                value={fullName}
-                onChange={(event) => setFullName(event.target.value)}
-                placeholder="Full Name"
-              />
-              <div className="helper-text" />
-            </div>
-
-            <div className="field">
-              <label className="field-label" htmlFor="title">
-                Title
-              </label>
-              <input
-                id="title"
-                className="text-input"
-                value={title}
-                onChange={(event) => setTitle(event.target.value)}
-                placeholder="Title"
-              />
-              <div className="helper-text" />
-            </div>
-
-            <div className="field">
-              <label className="field-label" htmlFor="company">
-                Company
-              </label>
-              <input
-                id="company"
-                className="text-input"
-                value={company}
-                onChange={(event) => setCompany(event.target.value)}
-                placeholder="Company"
-              />
-              <div className="helper-text" />
-            </div>
-
-            <div className="field">
-              <label className="field-label" htmlFor="location">
-                Location
-              </label>
-              <input
-                id="location"
-                className="text-input"
-                value={location}
-                onChange={(event) => setLocation(event.target.value)}
-                placeholder="Location"
-              />
-              <div className="helper-text" />
-            </div>
-
-            <div
-              className={`field${
-                fieldStatus.email === "error"
-                  ? " error"
-                  : fieldStatus.email === "success"
-                  ? " success"
-                  : ""
-              }`}
-            >
-              <label className="field-label" htmlFor="email">
-                Email
-              </label>
-              <input
-                id="email"
-                className="text-input"
-                value={email}
-                onChange={(event) => setEmail(event.target.value)}
-                onBlur={(event) => handleBlur("email", event.target.value)}
-                onKeyDown={handleEmailKeyDown}
-                placeholder="Email"
-                inputMode="email"
-                autoComplete="email"
-              />
-              <span className="success-indicator">
-                <IconCheck />
-              </span>
-              <div className={`validation-text${fieldErrors.email ? " error" : ""}`}>
-                {fieldErrors.email}
+          {activeTab === "email" && (
+            <>
+              <div className="email-context" role="note">
+                {contactId.trim()
+                  ? `Emailing contact #${contactId}.`
+                  : "View a contact first to load their email."}
               </div>
-            </div>
+              <div className="rolodex-form-grid email">
+                <div className="field">
+                  <label className="field-label" htmlFor="subject">
+                    Subject
+                  </label>
+                  <input
+                    id="subject"
+                    className="text-input"
+                    value={subject}
+                    onChange={(event) => setSubject(event.target.value)}
+                    onKeyDown={handleSubjectKeyDown}
+                    placeholder="Subject"
+                  />
+                  <div className="helper-text" />
+                </div>
 
-            <div
-              className={`field${
-                fieldStatus.profileUrl === "error"
-                  ? " error"
-                  : fieldStatus.profileUrl === "success"
-                  ? " success"
-                  : ""
-              }`}
-            >
-              <label className="field-label" htmlFor="profileUrl">
-                Profile URL
-              </label>
-              <input
-                id="profileUrl"
-                className="text-input"
-                value={profileUrl}
-                onChange={(event) => setProfileUrl(event.target.value)}
-                onBlur={(event) => handleBlur("profileUrl", event.target.value)}
-                placeholder="Profile URL"
-                inputMode="url"
-              />
-              <span className="success-indicator">
-                <IconCheck />
-              </span>
-              <div className={`validation-text${fieldErrors.profileUrl ? " error" : ""}`}>
-                {fieldErrors.profileUrl}
+                <div className="field">
+                  <label className="field-label" htmlFor="message">
+                    Message
+                  </label>
+                  <textarea
+                    id="message"
+                    className="text-area"
+                    value={message}
+                    onChange={(event) => setMessage(event.target.value)}
+                    onKeyDown={handleMessageKeyDown}
+                    placeholder="Message"
+                    rows={6}
+                  />
+                  <div className="helper-text" />
+                </div>
               </div>
-            </div>
-
-            <div className="field double">
-              <label className="field-label" htmlFor="subject">
-                Subject
-              </label>
-              <input
-                id="subject"
-                className="text-input"
-                value={subject}
-                onChange={(event) => setSubject(event.target.value)}
-                onKeyDown={handleSubjectKeyDown}
-                placeholder="Subject"
-              />
-              <div className="helper-text" />
-            </div>
-
-            <div className="field double">
-              <label className="field-label" htmlFor="message">
-                Message
-              </label>
-              <textarea
-                id="message"
-                className="text-area"
-                value={message}
-                onChange={(event) => setMessage(event.target.value)}
-                onKeyDown={handleMessageKeyDown}
-                placeholder="Message"
-                rows={6}
-              />
-              <div className="helper-text" />
-            </div>
-          </div>
+            </>
+          )}
 
           <div className="action-row">
             <button
+              ref={activeTab === "email" ? emailButtonRef : null}
               type="submit"
-              value="create"
-              className="button"
+              className={buttonClassName}
               disabled={disableSubmit}
-              aria-busy={loadingAction === "create"}
+              aria-busy={isLoading}
             >
-              {loadingAction === "create" ? <IconLoader /> : null}
-              {loadingAction === "create" ? "Creating…" : "Create"}
-            </button>
-            <button
-              type="submit"
-              value="update"
-              className="button secondary"
-              disabled={disableSubmit}
-              aria-busy={loadingAction === "update"}
-            >
-              {loadingAction === "update" ? <IconLoader /> : null}
-              {loadingAction === "update" ? "Updating…" : "Update"}
-            </button>
-            <button
-              type="submit"
-              value="view"
-              className="button secondary"
-              disabled={disableSubmit}
-              aria-busy={loadingAction === "view"}
-            >
-              {loadingAction === "view" ? <IconLoader /> : null}
-              {loadingAction === "view" ? "Viewing…" : "View"}
-            </button>
-            <button
-              ref={emailButtonRef}
-              type="submit"
-              value="email"
-              className="button ghost"
-              disabled={disableSubmit}
-              aria-busy={loadingAction === "email"}
-            >
-              {loadingAction === "email" ? <IconLoader /> : null}
-              {loadingAction === "email" ? "Sending…" : "Email"}
+              {isLoading ? <IconLoader /> : null}
+              {submitLabel}
             </button>
           </div>
         </form>
@@ -817,14 +1124,81 @@ export default function Rolodex() {
               {inlineSummary}
             </div>
           )}
-          {response && (
+          {lastAction === "view" && !errorMessage && viewRecords.length === 0 && response && (
+            <div className="inline-result" role="note">
+              No contacts found.
+            </div>
+          )}
+          {lastAction === "view" && viewRecords.length > 0 && (
+            <div className="view-table-wrapper" aria-live="polite">
+              <table className="view-table">
+                <thead>
+                  <tr>
+                    {VIEW_COLUMNS.map((column) => (
+                      <th key={column.key} scope="col">
+                        {column.label}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {viewRecords.map((record, index) => (
+                    <tr key={record.local_id ?? index}>
+                      {VIEW_COLUMNS.map((column) => {
+                        const rawValue = record?.[column.key];
+                        if (column.key === "profile_url") {
+                          if (!rawValue) {
+                            return (
+                              <td key={column.key} data-label={column.label}>
+                                —
+                              </td>
+                            );
+                          }
+                          const valueString = String(rawValue);
+                          return (
+                            <td key={column.key} data-label={column.label}>
+                              <a
+                                href={normalizeProfileHref(valueString)}
+                                target="_blank"
+                                rel="noreferrer noopener"
+                              >
+                                {valueString}
+                              </a>
+                            </td>
+                          );
+                        }
+                        if (column.key === "last_updated") {
+                          const formatted = rawValue ? formatDateTime(rawValue) : "";
+                          return (
+                            <td key={column.key} data-label={column.label}>
+                              {formatted || "—"}
+                            </td>
+                          );
+                        }
+                        const displayValue =
+                          rawValue === null || rawValue === undefined || rawValue === ""
+                            ? "—"
+                            : String(rawValue);
+                        return (
+                          <td key={column.key} data-label={column.label}>
+                            {displayValue}
+                          </td>
+                        );
+                      })}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+          {response && lastAction && lastAction !== "view" && (
             <pre className="response-view" aria-live="polite">
               {JSON.stringify(response, null, 2)}
             </pre>
           )}
         </div>
 
-        {!response && !inlineSummary && !errorMessage && (
+        {!response && viewRecords.length === 0 && !inlineSummary && !errorMessage && (
           <div className="empty-footer">No contact selected.</div>
         )}
       </section>

--- a/app/rolodex/rolodex.css
+++ b/app/rolodex/rolodex.css
@@ -166,6 +166,135 @@
   gap: 24px;
 }
 
+.tab-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 6px;
+  border-radius: 9999px;
+  background: rgba(148, 163, 184, 0.2);
+  align-self: flex-start;
+}
+
+.tab-button {
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  font-weight: 600;
+  font-size: 0.9rem;
+  padding: 8px 16px;
+  border-radius: 9999px;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.tab-button.active {
+  background: rgba(37, 99, 235, 0.18);
+  color: var(--text-primary);
+  box-shadow: inset 0 0 0 1px rgba(37, 99, 235, 0.4);
+}
+
+.tab-button:not(.active):hover,
+.tab-button:not(.active):focus-visible {
+  background: rgba(148, 163, 184, 0.25);
+  outline: none;
+}
+
+.tab-button:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.rolodex-form-grid.single {
+  grid-template-columns: minmax(0, 360px);
+}
+
+.rolodex-form-grid.email {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.email-context {
+  padding: 12px 16px;
+  border-radius: 14px;
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--text-secondary);
+  font-size: 0.88rem;
+}
+
+.view-table-wrapper {
+  margin-top: 12px;
+  border-radius: 16px;
+  border: 1px solid var(--card-border);
+  overflow-x: auto;
+  background: rgba(255, 255, 255, 0.88);
+}
+
+.view-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 720px;
+}
+
+.view-table th,
+.view-table td {
+  padding: 12px 16px;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.35);
+  text-align: left;
+  font-size: 0.9rem;
+}
+
+.view-table th {
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+}
+
+.view-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.view-table a {
+  color: var(--info);
+  text-decoration: none;
+}
+
+.view-table a:hover,
+.view-table a:focus-visible {
+  text-decoration: underline;
+  outline: none;
+}
+
+@media (prefers-color-scheme: dark) {
+  .tab-list {
+    background: rgba(51, 65, 85, 0.35);
+  }
+
+  .tab-button.active {
+    box-shadow: inset 0 0 0 1px rgba(96, 165, 250, 0.55);
+  }
+
+  .tab-button:not(.active):hover,
+  .tab-button:not(.active):focus-visible {
+    background: rgba(71, 85, 105, 0.35);
+  }
+
+  .email-context {
+    background: rgba(37, 99, 235, 0.24);
+    color: rgba(226, 232, 240, 0.9);
+  }
+
+  .view-table-wrapper {
+    background: rgba(15, 23, 42, 0.72);
+    border-color: rgba(71, 85, 105, 0.6);
+  }
+
+  .view-table th,
+  .view-table td {
+    border-color: rgba(71, 85, 105, 0.45);
+  }
+}
+
 .rolodex-form-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/app/rolodex/rolodex.css
+++ b/app/rolodex/rolodex.css
@@ -17,20 +17,32 @@
   --field-helper-height: 18px;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --surface-background: #0f172a;
-    --card-background: rgba(15, 23, 42, 0.92);
-    --card-border: rgba(71, 85, 105, 0.65);
-    --text-primary: rgba(248, 250, 252, 0.95);
-    --text-secondary: rgba(226, 232, 240, 0.72);
-    --input-background: rgba(15, 23, 42, 0.85);
-    --input-border: rgba(100, 116, 139, 0.6);
-    --input-border-strong: rgba(96, 165, 250, 0.9);
-    --input-placeholder: rgba(148, 163, 184, 0.7);
-    --shadow-sm: 0 16px 36px -18px rgba(15, 23, 42, 0.7);
-    --shadow-inner: 0 1px 0 rgba(255, 255, 255, 0.06);
-  }
+.theme-dark {
+  --surface-background: #0f172a;
+  --card-background: rgba(15, 23, 42, 0.92);
+  --card-border: rgba(71, 85, 105, 0.65);
+  --text-primary: rgba(248, 250, 252, 0.95);
+  --text-secondary: rgba(226, 232, 240, 0.72);
+  --input-background: rgba(15, 23, 42, 0.85);
+  --input-border: rgba(100, 116, 139, 0.6);
+  --input-border-strong: rgba(96, 165, 250, 0.9);
+  --input-placeholder: rgba(148, 163, 184, 0.7);
+  --shadow-sm: 0 16px 36px -18px rgba(15, 23, 42, 0.7);
+  --shadow-inner: 0 1px 0 rgba(255, 255, 255, 0.06);
+}
+
+.theme-light {
+  --surface-background: #f8fafc;
+  --card-background: rgba(255, 255, 255, 0.94);
+  --card-border: rgba(148, 163, 184, 0.4);
+  --text-primary: #0f172a;
+  --text-secondary: #475569;
+  --input-background: rgba(255, 255, 255, 0.9);
+  --input-border: rgba(148, 163, 184, 0.6);
+  --input-border-strong: #2563eb;
+  --input-placeholder: rgba(100, 116, 139, 0.7);
+  --shadow-sm: 0 10px 30px -12px rgba(15, 23, 42, 0.18);
+  --shadow-inner: 0 1px 0 rgba(255, 255, 255, 0.3);
 }
 
 .rolodex-page {
@@ -38,9 +50,45 @@
   display: flex;
   justify-content: center;
   padding: 48px 24px 64px;
+  position: relative;
   background: radial-gradient(circle at 0% 0%, rgba(59, 130, 246, 0.08), transparent 55%),
     radial-gradient(circle at 100% 0%, rgba(236, 72, 153, 0.08), transparent 55%),
     var(--surface-background);
+}
+
+.theme-toggle {
+  position: absolute;
+  top: 16px;
+  left: 16px;
+  padding: 10px 16px;
+  border-radius: 9999px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: rgba(255, 255, 255, 0.88);
+  color: var(--text-primary);
+  font-weight: 600;
+  font-size: 0.85rem;
+  cursor: pointer;
+  box-shadow: 0 6px 18px -12px rgba(15, 23, 42, 0.45);
+  transition: transform 0.15s ease, box-shadow 0.2s ease, background 0.2s ease, color 0.2s ease;
+  z-index: 20;
+}
+
+.theme-toggle:hover,
+.theme-toggle:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 24px -16px rgba(37, 99, 235, 0.3);
+  outline: none;
+}
+
+.theme-toggle:active {
+  transform: translateY(0);
+}
+
+.theme-dark .theme-toggle {
+  background: rgba(15, 23, 42, 0.88);
+  border-color: rgba(71, 85, 105, 0.6);
+  color: rgba(248, 250, 252, 0.9);
+  box-shadow: 0 12px 28px -20px rgba(15, 23, 42, 0.8);
 }
 
 .rolodex-card {
@@ -210,7 +258,7 @@
 }
 
 .rolodex-form-grid.email {
-  grid-template-columns: minmax(0, 1fr);
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
 }
 
 .email-context {
@@ -226,7 +274,7 @@
   border-radius: 16px;
   border: 1px solid var(--card-border);
   overflow-x: auto;
-  background: rgba(255, 255, 255, 0.88);
+  background: var(--card-background);
 }
 
 .view-table {
@@ -265,34 +313,66 @@
   outline: none;
 }
 
-@media (prefers-color-scheme: dark) {
-  .tab-list {
-    background: rgba(51, 65, 85, 0.35);
-  }
+.recency-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 10px;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  background: rgba(148, 163, 184, 0.16);
+  color: var(--text-secondary);
+}
 
-  .tab-button.active {
-    box-shadow: inset 0 0 0 1px rgba(96, 165, 250, 0.55);
-  }
+.recency-badge.fresh {
+  background: rgba(34, 197, 94, 0.16);
+  color: #15803d;
+}
 
-  .tab-button:not(.active):hover,
-  .tab-button:not(.active):focus-visible {
-    background: rgba(71, 85, 105, 0.35);
-  }
+.recency-badge.warm {
+  background: rgba(245, 158, 11, 0.18);
+  color: #b45309;
+}
 
-  .email-context {
-    background: rgba(37, 99, 235, 0.24);
-    color: rgba(226, 232, 240, 0.9);
-  }
+.recency-badge.stale {
+  background: rgba(239, 68, 68, 0.18);
+  color: #b91c1c;
+}
 
-  .view-table-wrapper {
-    background: rgba(15, 23, 42, 0.72);
-    border-color: rgba(71, 85, 105, 0.6);
-  }
+.recency-badge.unknown {
+  background: rgba(148, 163, 184, 0.16);
+  color: var(--text-secondary);
+}
 
-  .view-table th,
-  .view-table td {
-    border-color: rgba(71, 85, 105, 0.45);
-  }
+.theme-dark .tab-list {
+  background: rgba(51, 65, 85, 0.35);
+}
+
+.theme-dark .tab-button.active {
+  box-shadow: inset 0 0 0 1px rgba(96, 165, 250, 0.55);
+}
+
+.theme-dark .tab-button:not(.active):hover,
+.theme-dark .tab-button:not(.active):focus-visible {
+  background: rgba(71, 85, 105, 0.35);
+}
+
+.theme-dark .email-context {
+  background: rgba(37, 99, 235, 0.24);
+  color: rgba(226, 232, 240, 0.9);
+}
+
+.theme-dark .view-table-wrapper {
+  background: rgba(15, 23, 42, 0.72);
+  border-color: rgba(71, 85, 105, 0.6);
+}
+
+.theme-dark .view-table th,
+.theme-dark .view-table td {
+  border-color: rgba(71, 85, 105, 0.45);
 }
 
 .rolodex-form-grid {
@@ -317,6 +397,10 @@
 
 .field.double {
   grid-column: span 2;
+}
+
+.field.full-width {
+  grid-column: 1 / -1;
 }
 
 .field-label {
@@ -344,6 +428,46 @@
   transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
 }
 
+.select-input {
+  width: 100%;
+  padding: 14px 16px;
+  border-radius: 14px;
+  border: 1px solid var(--input-border);
+  background: var(--input-background);
+  color: var(--text-primary);
+  font-size: 0.95rem;
+  line-height: 1.4;
+  box-shadow: var(--shadow-inner);
+  appearance: none;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.select-input:hover {
+  box-shadow: var(--shadow-inner), 0 6px 18px -18px rgba(15, 23, 42, 0.6);
+}
+
+.select-input:focus {
+  outline: 3px solid rgba(37, 99, 235, 0.28);
+  outline-offset: 2px;
+  border-color: var(--input-border-strong);
+  background: rgba(255, 255, 255, 0.98);
+}
+
+.select-input:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.input-with-action {
+  display: flex;
+  gap: 10px;
+  align-items: stretch;
+}
+
+.input-with-action .text-input {
+  flex: 1 1 auto;
+}
+
 .text-input::placeholder,
 .text-area::placeholder {
   color: var(--input-placeholder);
@@ -362,11 +486,10 @@
   background: rgba(255, 255, 255, 0.98);
 }
 
-@media (prefers-color-scheme: dark) {
-  .text-input:focus,
-  .text-area:focus {
-    background: rgba(15, 23, 42, 0.95);
-  }
+.theme-dark .text-input:focus,
+.theme-dark .text-area:focus,
+.theme-dark .select-input:focus {
+  background: rgba(15, 23, 42, 0.95);
 }
 
 .field.error .text-input,
@@ -447,6 +570,13 @@
   .action-row .button {
     width: 100%;
   }
+  .input-with-action {
+    flex-direction: column;
+    gap: 12px;
+  }
+  .input-with-action .button {
+    width: 100%;
+  }
 }
 
 .button {
@@ -464,6 +594,13 @@
   background: rgba(37, 99, 235, 0.9);
   color: white;
   box-shadow: 0 12px 28px -16px rgba(37, 99, 235, 0.9);
+}
+
+.button.compact {
+  padding: 10px 16px;
+  border-radius: 10px;
+  font-size: 0.85rem;
+  gap: 6px;
 }
 
 .button.secondary {
@@ -562,27 +699,29 @@
   color: rgba(127, 29, 29, 0.96);
 }
 
-@media (prefers-color-scheme: dark) {
-  .toast {
-    background: rgba(15, 23, 42, 0.92);
-    color: rgba(226, 232, 240, 0.92);
-  }
-  .toast-close:hover,
-  .toast-close:focus-visible {
-    background: rgba(148, 163, 184, 0.16);
-  }
-  .toast.success {
-    background: rgba(34, 197, 94, 0.14);
-    color: rgba(187, 247, 208, 0.95);
-  }
-  .toast.info {
-    background: rgba(59, 130, 246, 0.14);
-    color: rgba(191, 219, 254, 0.95);
-  }
-  .toast.error {
-    background: rgba(239, 68, 68, 0.16);
-    color: rgba(254, 226, 226, 0.96);
-  }
+.theme-dark .toast {
+  background: rgba(15, 23, 42, 0.92);
+  color: rgba(226, 232, 240, 0.92);
+}
+
+.theme-dark .toast-close:hover,
+.theme-dark .toast-close:focus-visible {
+  background: rgba(148, 163, 184, 0.16);
+}
+
+.theme-dark .toast.success {
+  background: rgba(34, 197, 94, 0.14);
+  color: rgba(187, 247, 208, 0.95);
+}
+
+.theme-dark .toast.info {
+  background: rgba(59, 130, 246, 0.14);
+  color: rgba(191, 219, 254, 0.95);
+}
+
+.theme-dark .toast.error {
+  background: rgba(239, 68, 68, 0.16);
+  color: rgba(254, 226, 226, 0.96);
 }
 
 .result-area {
@@ -620,11 +759,9 @@ pre.response-view {
   font-size: 0.85rem;
 }
 
-@media (prefers-color-scheme: light) {
-  pre.response-view {
-    background: rgba(15, 23, 42, 0.9);
-    color: #f8fafc;
-  }
+.theme-light pre.response-view {
+  background: rgba(15, 23, 42, 0.9);
+  color: #f8fafc;
 }
 
 @media (max-width: 640px) {


### PR DESCRIPTION
## Summary
- add a Gmail status check with persistent username storage so the Rolodex email tab only marks OAuth as connected when tokens are present
- gate email submissions on a loaded contact address and call a new `/api/gmail/send` route to deliver messages through Gmail
- expose `/api/oauth/google/status` and `/api/gmail/send` endpoints for token lookups, refresh handling, and Gmail message delivery

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de3abaf1788320a089a1ca7cd2935f