### PR TITLE
Add NextAuth scaffolding for Gmail API testing

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,42 @@
+import NextAuth from "next-auth";
+import GoogleProvider from "next-auth/providers/google";
+
+const handler = NextAuth({
+  providers: [
+    GoogleProvider({
+      clientId: process.env.GOOGLE_CLIENT_ID!,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+      authorization: {
+        params: {
+          scope: [
+            "openid",
+            "email",
+            "profile",
+            "https://www.googleapis.com/auth/gmail.send",
+          ].join(" "),
+          access_type: "offline",
+          prompt: "consent",
+        },
+      },
+    }),
+  ],
+  callbacks: {
+    async jwt({ token, account }) {
+      if (account) {
+        token.access_token = account.access_token;
+        token.refresh_token = account.refresh_token;
+        token.expires_at = (account.expires_at ?? 0) * 1000;
+      }
+      return token;
+    },
+    async session({ session, token }) {
+      session.access_token = token.access_token as string | undefined;
+      session.refresh_token = token.refresh_token as string | undefined;
+      session.expires_at = token.expires_at as number | undefined;
+      return session;
+    },
+  },
+  secret: process.env.NEXTAUTH_SECRET,
+});
+
+export { handler as GET, handler as POST };

--- a/app/api/gmail/send/route.ts
+++ b/app/api/gmail/send/route.ts
@@ -1,0 +1,162 @@
+import { NextRequest, NextResponse } from "next/server";
+import crypto from "crypto";
+import { Pool } from "pg";
+
+export const runtime = "nodejs";
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+
+function decrypt(buffer: Buffer) {
+  const key = Buffer.from(process.env.ENCRYPTION_KEY!, "utf8");
+  const iv = buffer.subarray(0, 12);
+  const tag = buffer.subarray(12, 28);
+  const data = buffer.subarray(28);
+  const decipher = crypto.createDecipheriv("aes-256-gcm", key, iv);
+  decipher.setAuthTag(tag);
+  const decrypted = Buffer.concat([decipher.update(data), decipher.final()]);
+  return decrypted.toString("utf8");
+}
+
+function base64UrlEncode(value: string) {
+  return Buffer.from(value, "utf8")
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
+}
+
+async function exchangeRefreshToken(refreshToken: string) {
+  const params = new URLSearchParams({
+    client_id: process.env.GOOGLE_CLIENT_ID!,
+    client_secret: process.env.GOOGLE_CLIENT_SECRET!,
+    grant_type: "refresh_token",
+    refresh_token: refreshToken,
+  });
+
+  const response = await fetch("https://oauth2.googleapis.com/token", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: params,
+  });
+
+  if (!response.ok) {
+    const detail = await response.text();
+    throw new Error(detail || "Failed to refresh Gmail access token.");
+  }
+
+  const json = (await response.json()) as { access_token?: string };
+  if (!json.access_token) {
+    throw new Error("Missing access token from Google response.");
+  }
+
+  return json.access_token;
+}
+
+async function sendMessage(accessToken: string, rawMessage: string) {
+  const response = await fetch(
+    "https://gmail.googleapis.com/gmail/v1/users/me/messages/send",
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ raw: base64UrlEncode(rawMessage) }),
+    }
+  );
+
+  const text = await response.text();
+  let data: unknown = null;
+  try {
+    data = text ? JSON.parse(text) : null;
+  } catch {
+    data = text;
+  }
+
+  if (!response.ok) {
+    const message =
+      (typeof data === "string" && data) ||
+      (data && typeof data === "object" && "error" in data && (data as any).error) ||
+      response.statusText ||
+      "Failed to send Gmail message.";
+    throw new Error(message);
+  }
+
+  return data;
+}
+
+export async function POST(req: NextRequest) {
+  let payload: unknown;
+  try {
+    payload = await req.json();
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+
+  const body = (payload ?? {}) as {
+    username?: string;
+    to?: string;
+    subject?: string;
+    message?: string;
+  };
+
+  const username = typeof body.username === "string" ? body.username.trim() : "";
+  const to = typeof body.to === "string" ? body.to.trim() : "";
+  const subject = typeof body.subject === "string" ? body.subject.trim() : "";
+  const message = typeof body.message === "string" ? body.message : "";
+
+  if (!username) {
+    return NextResponse.json({ error: "missing_username" }, { status: 400 });
+  }
+  if (!to) {
+    return NextResponse.json({ error: "missing_recipient" }, { status: 400 });
+  }
+  if (!message.trim()) {
+    return NextResponse.json({ error: "missing_message" }, { status: 400 });
+  }
+
+  const tokenRow = await pool.query(
+    "select refresh_token_enc, google_email from user_gmail_tokens where user_id = $1",
+    [username]
+  );
+
+  if (tokenRow.rowCount === 0) {
+    return NextResponse.json({ error: "not_connected" }, { status: 404 });
+  }
+
+  const row = tokenRow.rows[0] as {
+    refresh_token_enc: Buffer;
+    google_email: string;
+  };
+  const refreshToken = decrypt(row.refresh_token_enc);
+
+  let accessToken: string;
+  try {
+    accessToken = await exchangeRefreshToken(refreshToken);
+  } catch (error) {
+    const messageText =
+      error instanceof Error ? error.message : "Failed to refresh Gmail access token.";
+    return NextResponse.json({ error: messageText }, { status: 502 });
+  }
+
+  const sender = row.google_email;
+  const lines = [
+    `From: ${sender}`,
+    `To: ${to}`,
+    `Subject: ${subject || ""}`,
+    "MIME-Version: 1.0",
+    "Content-Type: text/plain; charset=\"UTF-8\"",
+    "Content-Transfer-Encoding: 7bit",
+    "",
+    message,
+  ];
+  const raw = lines.join("\r\n");
+
+  try {
+    const gmailResponse = await sendMessage(accessToken, raw);
+    return NextResponse.json({ success: true, gmail: gmailResponse });
+  } catch (error) {
+    const messageText = error instanceof Error ? error.message : "Failed to send Gmail message.";
+    return NextResponse.json({ error: messageText }, { status: 502 });
+  }
+}

--- a/app/api/oauth/google/status/route.ts
+++ b/app/api/oauth/google/status/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from "next/server";
+import { Pool } from "pg";
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+
+export const runtime = "nodejs";
+
+export async function GET(req: NextRequest) {
+  const username = req.nextUrl.searchParams.get("username")?.trim();
+  if (!username) {
+    return NextResponse.json({ error: "missing_username" }, { status: 400 });
+  }
+
+  const result = await pool.query(
+    "select google_email from user_gmail_tokens where user_id = $1",
+    [username]
+  );
+
+  if (result.rowCount === 0) {
+    return NextResponse.json({ error: "not_connected" }, { status: 404 });
+  }
+
+  return NextResponse.json({ email: result.rows[0].google_email });
+}

--- a/app/api/send/route.ts
+++ b/app/api/send/route.ts
@@ -1,0 +1,55 @@
+import { google } from "googleapis";
+import { getServerSession } from "next-auth";
+import { NextResponse } from "next/server";
+
+export const runtime = "nodejs";
+
+export async function POST() {
+  try {
+    const session = await getServerSession();
+    if (!session?.access_token) {
+      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+    }
+
+    const oauth2 = new google.auth.OAuth2(
+      process.env.GOOGLE_CLIENT_ID,
+      process.env.GOOGLE_CLIENT_SECRET,
+      process.env.NEXTAUTH_URL + "/api/auth/callback/google"
+    );
+
+    oauth2.setCredentials({
+      access_token: session.access_token,
+      refresh_token: session.refresh_token,
+    });
+
+    const gmail = google.gmail({ version: "v1", auth: oauth2 });
+
+    const raw = Buffer.from(
+      [
+        "Content-Type: text/plain; charset=utf-8",
+        "MIME-Version: 1.0",
+        "Content-Transfer-Encoding: 7bit",
+        `to: recipient@example.com`,
+        `from: ${session.user?.email}`,
+        "subject: Hello from Vercel + Gmail API",
+        "",
+        "It works. Cheers!",
+      ].join("\n")
+    )
+      .toString("base64")
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+
+    await gmail.users.messages.send({
+      userId: "me",
+      requestBody: { raw },
+    });
+
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    console.error(error);
+    const message = error instanceof Error ? error.message : "Unknown error";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/app/layout.js
+++ b/app/layout.js
@@ -1,4 +1,5 @@
 import "./globals.css";
+import Providers from "./providers";
 
 export const metadata = { title: "My UI" };
 
@@ -6,7 +7,7 @@ export default function RootLayout({ children }) {
   return (
     <html lang="en">
       <body className="app-shell">
-        {children}
+        <Providers>{children}</Providers>
       </body>
     </html>
   );

--- a/app/page.js
+++ b/app/page.js
@@ -1,1 +1,0 @@
-export { default } from "./rolodex/page";

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import Link from "next/link";
+import { signIn, signOut, useSession } from "next-auth/react";
+
+export default function Home() {
+  const { data: session, status } = useSession();
+
+  const send = async () => {
+    const response = await fetch("/api/send", { method: "POST" });
+    const text = await response.text();
+    alert(text);
+  };
+
+  if (status === "loading") {
+    return <p>Loading…</p>;
+  }
+
+  return (
+    <main style={{ padding: 24, display: "grid", gap: 16 }}>
+      {!session ? (
+        <button onClick={() => signIn("google")}>Sign in with Google</button>
+      ) : (
+        <>
+          <p>Signed in as {session.user?.email}</p>
+          <button onClick={send}>Send test email</button>
+          <button onClick={() => signOut()}>Sign out</button>
+        </>
+      )}
+      <Link href="/rolodex">Go to Rolodex</Link>
+    </main>
+  );
+}

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import { SessionProvider } from "next-auth/react";
+import { ReactNode } from "react";
+
+export default function Providers({ children }: { children: ReactNode }) {
+  return <SessionProvider>{children}</SessionProvider>;
+}

--- a/app/rolodex/rolodex.css
+++ b/app/rolodex/rolodex.css
@@ -17,20 +17,32 @@
   --field-helper-height: 18px;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --surface-background: #0f172a;
-    --card-background: rgba(15, 23, 42, 0.92);
-    --card-border: rgba(71, 85, 105, 0.65);
-    --text-primary: rgba(248, 250, 252, 0.95);
-    --text-secondary: rgba(226, 232, 240, 0.72);
-    --input-background: rgba(15, 23, 42, 0.85);
-    --input-border: rgba(100, 116, 139, 0.6);
-    --input-border-strong: rgba(96, 165, 250, 0.9);
-    --input-placeholder: rgba(148, 163, 184, 0.7);
-    --shadow-sm: 0 16px 36px -18px rgba(15, 23, 42, 0.7);
-    --shadow-inner: 0 1px 0 rgba(255, 255, 255, 0.06);
-  }
+.theme-dark {
+  --surface-background: #0f172a;
+  --card-background: rgba(15, 23, 42, 0.92);
+  --card-border: rgba(71, 85, 105, 0.65);
+  --text-primary: rgba(248, 250, 252, 0.95);
+  --text-secondary: rgba(226, 232, 240, 0.72);
+  --input-background: rgba(15, 23, 42, 0.85);
+  --input-border: rgba(100, 116, 139, 0.6);
+  --input-border-strong: rgba(96, 165, 250, 0.9);
+  --input-placeholder: rgba(148, 163, 184, 0.7);
+  --shadow-sm: 0 16px 36px -18px rgba(15, 23, 42, 0.7);
+  --shadow-inner: 0 1px 0 rgba(255, 255, 255, 0.06);
+}
+
+.theme-light {
+  --surface-background: #f8fafc;
+  --card-background: rgba(255, 255, 255, 0.94);
+  --card-border: rgba(148, 163, 184, 0.4);
+  --text-primary: #0f172a;
+  --text-secondary: #475569;
+  --input-background: rgba(255, 255, 255, 0.9);
+  --input-border: rgba(148, 163, 184, 0.6);
+  --input-border-strong: #2563eb;
+  --input-placeholder: rgba(100, 116, 139, 0.7);
+  --shadow-sm: 0 10px 30px -12px rgba(15, 23, 42, 0.18);
+  --shadow-inner: 0 1px 0 rgba(255, 255, 255, 0.3);
 }
 
 .rolodex-page {
@@ -38,9 +50,45 @@
   display: flex;
   justify-content: center;
   padding: 48px 24px 64px;
+  position: relative;
   background: radial-gradient(circle at 0% 0%, rgba(59, 130, 246, 0.08), transparent 55%),
     radial-gradient(circle at 100% 0%, rgba(236, 72, 153, 0.08), transparent 55%),
     var(--surface-background);
+}
+
+.theme-toggle {
+  position: absolute;
+  top: 16px;
+  left: 16px;
+  padding: 10px 16px;
+  border-radius: 9999px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: rgba(255, 255, 255, 0.88);
+  color: var(--text-primary);
+  font-weight: 600;
+  font-size: 0.85rem;
+  cursor: pointer;
+  box-shadow: 0 6px 18px -12px rgba(15, 23, 42, 0.45);
+  transition: transform 0.15s ease, box-shadow 0.2s ease, background 0.2s ease, color 0.2s ease;
+  z-index: 20;
+}
+
+.theme-toggle:hover,
+.theme-toggle:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 24px -16px rgba(37, 99, 235, 0.3);
+  outline: none;
+}
+
+.theme-toggle:active {
+  transform: translateY(0);
+}
+
+.theme-dark .theme-toggle {
+  background: rgba(15, 23, 42, 0.88);
+  border-color: rgba(71, 85, 105, 0.6);
+  color: rgba(248, 250, 252, 0.9);
+  box-shadow: 0 12px 28px -20px rgba(15, 23, 42, 0.8);
 }
 
 .rolodex-card {
@@ -166,6 +214,167 @@
   gap: 24px;
 }
 
+.tab-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 6px;
+  border-radius: 9999px;
+  background: rgba(148, 163, 184, 0.2);
+  align-self: flex-start;
+}
+
+.tab-button {
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  font-weight: 600;
+  font-size: 0.9rem;
+  padding: 8px 16px;
+  border-radius: 9999px;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.tab-button.active {
+  background: rgba(37, 99, 235, 0.18);
+  color: var(--text-primary);
+  box-shadow: inset 0 0 0 1px rgba(37, 99, 235, 0.4);
+}
+
+.tab-button:not(.active):hover,
+.tab-button:not(.active):focus-visible {
+  background: rgba(148, 163, 184, 0.25);
+  outline: none;
+}
+
+.tab-button:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.rolodex-form-grid.single {
+  grid-template-columns: minmax(0, 360px);
+}
+
+.rolodex-form-grid.email {
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.email-context {
+  padding: 12px 16px;
+  border-radius: 14px;
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--text-secondary);
+  font-size: 0.88rem;
+}
+
+.view-table-wrapper {
+  margin-top: 12px;
+  border-radius: 16px;
+  border: 1px solid var(--card-border);
+  overflow-x: auto;
+  background: var(--card-background);
+}
+
+.view-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 720px;
+}
+
+.view-table th,
+.view-table td {
+  padding: 12px 16px;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.35);
+  text-align: left;
+  font-size: 0.9rem;
+}
+
+.view-table th {
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+}
+
+.view-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.view-table a {
+  color: var(--info);
+  text-decoration: none;
+}
+
+.view-table a:hover,
+.view-table a:focus-visible {
+  text-decoration: underline;
+  outline: none;
+}
+
+.recency-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 10px;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  background: rgba(148, 163, 184, 0.16);
+  color: var(--text-secondary);
+}
+
+.recency-badge.fresh {
+  background: rgba(34, 197, 94, 0.16);
+  color: #15803d;
+}
+
+.recency-badge.warm {
+  background: rgba(245, 158, 11, 0.18);
+  color: #b45309;
+}
+
+.recency-badge.stale {
+  background: rgba(239, 68, 68, 0.18);
+  color: #b91c1c;
+}
+
+.recency-badge.unknown {
+  background: rgba(148, 163, 184, 0.16);
+  color: var(--text-secondary);
+}
+
+.theme-dark .tab-list {
+  background: rgba(51, 65, 85, 0.35);
+}
+
+.theme-dark .tab-button.active {
+  box-shadow: inset 0 0 0 1px rgba(96, 165, 250, 0.55);
+}
+
+.theme-dark .tab-button:not(.active):hover,
+.theme-dark .tab-button:not(.active):focus-visible {
+  background: rgba(71, 85, 105, 0.35);
+}
+
+.theme-dark .email-context {
+  background: rgba(37, 99, 235, 0.24);
+  color: rgba(226, 232, 240, 0.9);
+}
+
+.theme-dark .view-table-wrapper {
+  background: rgba(15, 23, 42, 0.72);
+  border-color: rgba(71, 85, 105, 0.6);
+}
+
+.theme-dark .view-table th,
+.theme-dark .view-table td {
+  border-color: rgba(71, 85, 105, 0.45);
+}
+
 .rolodex-form-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -188,6 +397,10 @@
 
 .field.double {
   grid-column: span 2;
+}
+
+.field.full-width {
+  grid-column: 1 / -1;
 }
 
 .field-label {
@@ -215,6 +428,46 @@
   transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
 }
 
+.select-input {
+  width: 100%;
+  padding: 14px 16px;
+  border-radius: 14px;
+  border: 1px solid var(--input-border);
+  background: var(--input-background);
+  color: var(--text-primary);
+  font-size: 0.95rem;
+  line-height: 1.4;
+  box-shadow: var(--shadow-inner);
+  appearance: none;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.select-input:hover {
+  box-shadow: var(--shadow-inner), 0 6px 18px -18px rgba(15, 23, 42, 0.6);
+}
+
+.select-input:focus {
+  outline: 3px solid rgba(37, 99, 235, 0.28);
+  outline-offset: 2px;
+  border-color: var(--input-border-strong);
+  background: rgba(255, 255, 255, 0.98);
+}
+
+.select-input:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.input-with-action {
+  display: flex;
+  gap: 10px;
+  align-items: stretch;
+}
+
+.input-with-action .text-input {
+  flex: 1 1 auto;
+}
+
 .text-input::placeholder,
 .text-area::placeholder {
   color: var(--input-placeholder);
@@ -233,11 +486,10 @@
   background: rgba(255, 255, 255, 0.98);
 }
 
-@media (prefers-color-scheme: dark) {
-  .text-input:focus,
-  .text-area:focus {
-    background: rgba(15, 23, 42, 0.95);
-  }
+.theme-dark .text-input:focus,
+.theme-dark .text-area:focus,
+.theme-dark .select-input:focus {
+  background: rgba(15, 23, 42, 0.95);
 }
 
 .field.error .text-input,
@@ -318,6 +570,13 @@
   .action-row .button {
     width: 100%;
   }
+  .input-with-action {
+    flex-direction: column;
+    gap: 12px;
+  }
+  .input-with-action .button {
+    width: 100%;
+  }
 }
 
 .button {
@@ -335,6 +594,13 @@
   background: rgba(37, 99, 235, 0.9);
   color: white;
   box-shadow: 0 12px 28px -16px rgba(37, 99, 235, 0.9);
+}
+
+.button.compact {
+  padding: 10px 16px;
+  border-radius: 10px;
+  font-size: 0.85rem;
+  gap: 6px;
 }
 
 .button.secondary {
@@ -433,27 +699,29 @@
   color: rgba(127, 29, 29, 0.96);
 }
 
-@media (prefers-color-scheme: dark) {
-  .toast {
-    background: rgba(15, 23, 42, 0.92);
-    color: rgba(226, 232, 240, 0.92);
-  }
-  .toast-close:hover,
-  .toast-close:focus-visible {
-    background: rgba(148, 163, 184, 0.16);
-  }
-  .toast.success {
-    background: rgba(34, 197, 94, 0.14);
-    color: rgba(187, 247, 208, 0.95);
-  }
-  .toast.info {
-    background: rgba(59, 130, 246, 0.14);
-    color: rgba(191, 219, 254, 0.95);
-  }
-  .toast.error {
-    background: rgba(239, 68, 68, 0.16);
-    color: rgba(254, 226, 226, 0.96);
-  }
+.theme-dark .toast {
+  background: rgba(15, 23, 42, 0.92);
+  color: rgba(226, 232, 240, 0.92);
+}
+
+.theme-dark .toast-close:hover,
+.theme-dark .toast-close:focus-visible {
+  background: rgba(148, 163, 184, 0.16);
+}
+
+.theme-dark .toast.success {
+  background: rgba(34, 197, 94, 0.14);
+  color: rgba(187, 247, 208, 0.95);
+}
+
+.theme-dark .toast.info {
+  background: rgba(59, 130, 246, 0.14);
+  color: rgba(191, 219, 254, 0.95);
+}
+
+.theme-dark .toast.error {
+  background: rgba(239, 68, 68, 0.16);
+  color: rgba(254, 226, 226, 0.96);
 }
 
 .result-area {
@@ -491,11 +759,9 @@ pre.response-view {
   font-size: 0.85rem;
 }
 
-@media (prefers-color-scheme: light) {
-  pre.response-view {
-    background: rgba(15, 23, 42, 0.9);
-    color: #f8fafc;
-  }
+.theme-light pre.response-view {
+  background: rgba(15, 23, 42, 0.9);
+  color: #f8fafc;
 }
 
 @media (max-width: 640px) {

--- a/next-auth.d.ts
+++ b/next-auth.d.ts
@@ -1,0 +1,20 @@
+import NextAuth, { DefaultSession } from "next-auth";
+
+declare module "next-auth" {
+  interface Session {
+    access_token?: string;
+    refresh_token?: string;
+    expires_at?: number;
+    user?: DefaultSession["user"];
+  }
+
+  interface Profile {}
+}
+
+declare module "next-auth/jwt" {
+  interface JWT {
+    access_token?: string;
+    refresh_token?: string;
+    expires_at?: number;
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,11 @@
       "version": "1.0.0",
       "dependencies": {
         "next": "14.2.5",
+        "next-auth": "^4.24.8",
         "pg": "^8.16.3",
         "react": "18.2.0",
-        "react-dom": "18.2.0"
+        "react-dom": "18.2.0",
+        "googleapis": "^129.0.0"
       },
       "devDependencies": {
         "@types/node": "20.14.12",

--- a/package.json
+++ b/package.json
@@ -9,9 +9,11 @@
   },
   "dependencies": {
     "next": "14.2.5",
+    "next-auth": "^4.24.8",
     "pg": "^8.16.3",
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "googleapis": "^129.0.0"
   },
   "devDependencies": {
     "@types/node": "20.14.12",


### PR DESCRIPTION
## Summary
- add a Google NextAuth provider with Gmail send scope and callbacks to expose access and refresh tokens in the session
- expose a node runtime `/api/send` route that uses the googleapis client and session credentials to send a sample email
- wrap the app with a SessionProvider and replace the index page with a simple sign-in/send UI while keeping the Rolodex reachable

## Testing
- npm run build *(fails: missing installed dependencies `next-auth` and `googleapis`; install them to build successfully)*

------
https://chatgpt.com/codex/tasks/task_e_68de3abaf1788320a089a1ca7cd2935f