### PR TITLE
Add placeholder NextAuth route to prevent 404s

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const NOT_IMPLEMENTED_MESSAGE = {
+  error: 'NextAuth is not yet configured on this deployment.',
+  hint: 'Add your NextAuth handler to app/api/auth/[...nextauth]/route.ts.',
+};
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(_request: NextRequest) {
+  return NextResponse.json(NOT_IMPLEMENTED_MESSAGE, { status: 501 });
+}
+
+export async function POST(_request: NextRequest) {
+  return NextResponse.json(NOT_IMPLEMENTED_MESSAGE, { status: 501 });
+}
+
+export async function OPTIONS() {
+  return new NextResponse(null, {
+    status: 204,
+    headers: {
+      Allow: 'GET,POST,OPTIONS',
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- add a dynamic app router catch-all handler for /api/auth to prevent 404s
- return a helpful message and OPTIONS response until NextAuth is configured

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1a81a924c8320be2f643446232a44