### PR TITLE
Add placeholder NextAuth API route

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server';
+
+/**
+ * Temporary handler to keep the auth callback route live in production.
+ * Replace with a NextAuth configuration when authentication is ready.
+ */
+function notImplementedResponse() {
+  return NextResponse.json(
+    {
+      error: 'NextAuth is not configured yet.',
+      message:
+        'This is a placeholder for /api/auth/[...nextauth]. Configure NextAuth to enable authentication.',
+    },
+    { status: 501 }
+  );
+}
+
+export async function GET() {
+  return notImplementedResponse();
+}
+
+export async function POST() {
+  return notImplementedResponse();
+}


### PR DESCRIPTION
## Summary
- add a temporary NextAuth catch-all route so /api/auth/signin no longer returns 404 in production

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1a81a924c8320be2f643446232a44