### PR TITLE
Add API auth signin route to forward to Google OAuth flow

### DIFF
--- a/app/api/auth/signin/route.ts
+++ b/app/api/auth/signin/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from "next/server";
+
+function buildRedirectUrl(req: NextRequest) {
+  const target = new URL("/api/oauth/google/start", req.nextUrl.origin);
+  req.nextUrl.searchParams.forEach((value, key) => {
+    target.searchParams.append(key, value);
+  });
+  return target;
+}
+
+export async function GET(req: NextRequest) {
+  const target = buildRedirectUrl(req);
+  return NextResponse.redirect(target);
+}
+
+export async function POST(req: NextRequest) {
+  const target = buildRedirectUrl(req);
+  return NextResponse.redirect(target, { status: 307 });
+}


### PR DESCRIPTION
## Summary
- add an /api/auth/signin route that forwards requests to the existing Google OAuth start handler
- support both GET and POST requests while preserving any incoming query parameters

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1ad2d086c832087c4dfb24bf23c53