### PR TITLE
Ensure Google OAuth redirect URI is always defined

### DIFF
--- a/app/api/auth/signin/route.ts
+++ b/app/api/auth/signin/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from "next/server";
+
+function buildRedirectUrl(req: NextRequest) {
+  const target = new URL("/api/oauth/google/start", req.nextUrl.origin);
+  req.nextUrl.searchParams.forEach((value, key) => {
+    target.searchParams.append(key, value);
+  });
+  return target;
+}
+
+export async function GET(req: NextRequest) {
+  const target = buildRedirectUrl(req);
+  return NextResponse.redirect(target);
+}
+
+export async function POST(req: NextRequest) {
+  const target = buildRedirectUrl(req);
+  return NextResponse.redirect(target, { status: 307 });
+}

--- a/app/api/oauth/google/callback/route.ts
+++ b/app/api/oauth/google/callback/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from "next/server";
 import crypto from "crypto";
 import { Pool } from "pg";
 
+import { resolveRedirectUri } from "../utils";
+
 const pool = new Pool({ connectionString: process.env.DATABASE_URL });
 
 function enc(plain: string) {
@@ -20,11 +22,13 @@ export async function GET(req: NextRequest) {
   if (!code || !stateRaw) return NextResponse.json({ error: "bad_request" }, { status: 400 });
   const { username } = JSON.parse(decodeURIComponent(stateRaw));
 
+  const redirectUri = resolveRedirectUri(req);
+
   const body = new URLSearchParams({
     code,
     client_id: process.env.GOOGLE_CLIENT_ID!,
     client_secret: process.env.GOOGLE_CLIENT_SECRET!,
-    redirect_uri: process.env.GOOGLE_REDIRECT_URI!,
+    redirect_uri: redirectUri,
     grant_type: "authorization_code",
   });
 

--- a/app/api/oauth/google/start/route.ts
+++ b/app/api/oauth/google/start/route.ts
@@ -1,8 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 
+import { resolveRedirectUri } from "../utils";
+
 export async function GET(req: NextRequest) {
   const clientId = process.env.GOOGLE_CLIENT_ID!;
-  const redirectUri = process.env.GOOGLE_REDIRECT_URI!;
+  const redirectUri = resolveRedirectUri(req);
   const scope = "https://www.googleapis.com/auth/gmail.send";
   // Replace with your auth/session username
   const username =

--- a/app/api/oauth/google/utils.ts
+++ b/app/api/oauth/google/utils.ts
@@ -1,0 +1,11 @@
+import { NextRequest } from "next/server";
+
+export function resolveRedirectUri(req: NextRequest) {
+  const envRedirect = process.env.GOOGLE_REDIRECT_URI;
+  if (envRedirect && envRedirect.length > 0) {
+    return envRedirect;
+  }
+
+  const origin = req.nextUrl.origin;
+  return `${origin}/api/oauth/google/callback`;
+}


### PR DESCRIPTION
## Summary
- add a shared helper to resolve the Google OAuth redirect URI, falling back to the current request origin when the environment variable is missing
- update the Google OAuth start and callback handlers to use the shared helper so the redirect_uri parameter is always populated

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1ad2d086c832087c4dfb24bf23c53