### PR TITLE
Add Google authentication and Gmail email API

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,45 @@
+import NextAuth, { NextAuthOptions } from "next-auth";
+import GoogleProvider from "next-auth/providers/google";
+
+const scopes = [
+  "openid",
+  "email",
+  "profile",
+  "https://www.googleapis.com/auth/gmail.send",
+].join(" ");
+
+export const authOptions: NextAuthOptions = {
+  providers: [
+    GoogleProvider({
+      clientId: process.env.GOOGLE_CLIENT_ID!,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+      authorization: {
+        params: {
+          scope: scopes,
+          access_type: "offline",
+          prompt: "consent",
+        },
+      },
+    }),
+  ],
+  callbacks: {
+    async jwt({ token, account }) {
+      if (account) {
+        token.access_token = account.access_token;
+        token.refresh_token = account.refresh_token ?? token.refresh_token;
+        token.expires_at = Date.now() + (account.expires_in ?? 3600) * 1000;
+      }
+      return token;
+    },
+    async session({ session, token }) {
+      (session as any).access_token = token.access_token;
+      (session as any).refresh_token = token.refresh_token;
+      (session as any).expires_at = token.expires_at;
+      return session;
+    },
+  },
+  secret: process.env.AUTH_SECRET,
+};
+
+const handler = NextAuth(authOptions);
+export { handler as GET, handler as POST };

--- a/app/api/send-email/route.ts
+++ b/app/api/send-email/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest } from "next/server";
+import { google } from "googleapis";
+import { getServerSession } from "next-auth";
+import { authOptions } from "../auth/[...nextauth]/route";
+
+function toBase64Url(str: string) {
+  return Buffer.from(str)
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+export async function POST(req: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return new Response("Unauthorised", { status: 401 });
+  }
+
+  const { to, subject, text, html } = await req.json();
+
+  const oauth2 = new google.auth.OAuth2(
+    process.env.GOOGLE_CLIENT_ID,
+    process.env.GOOGLE_CLIENT_SECRET
+  );
+
+  oauth2.setCredentials({
+    access_token: (session as any).access_token,
+    refresh_token: (session as any).refresh_token,
+  });
+
+  const gmail = google.gmail({ version: "v1", auth: oauth2 });
+
+  const from = session.user?.email ?? "";
+  const body = html ?? (text ? text.replace(/\n/g, "<br/>") : "");
+  const rawLines = [
+    `From: ${from}`,
+    `To: ${to}`,
+    `Subject: ${subject}`,
+    "MIME-Version: 1.0",
+    "Content-Type: text/html; charset=UTF-8",
+    "",
+    body,
+  ];
+  const raw = toBase64Url(rawLines.join("\n"));
+
+  await gmail.users.messages.send({
+    userId: "me",
+    requestBody: { raw },
+  });
+
+  return Response.json({ ok: true });
+}

--- a/app/components/AuthButton.jsx
+++ b/app/components/AuthButton.jsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { signIn, signOut, useSession } from "next-auth/react";
+
+export default function AuthButton() {
+  const { data: session, status } = useSession();
+
+  if (status === "loading") {
+    return (
+      <button type="button" className="button secondary" disabled>
+        Loading…
+      </button>
+    );
+  }
+
+  if (!session) {
+    return (
+      <button type="button" className="button secondary" onClick={() => signIn("google")}>
+        Sign in with Google
+      </button>
+    );
+  }
+
+  return (
+    <div className="auth-button">
+      <p className="auth-greeting">Hi {session.user?.name}</p>
+      <button type="button" className="button secondary" onClick={() => signOut()}>
+        Sign out
+      </button>
+    </div>
+  );
+}

--- a/app/layout.js
+++ b/app/layout.js
@@ -1,4 +1,5 @@
 import "./globals.css";
+import { Providers } from "./providers";
 
 export const metadata = { title: "My UI" };
 
@@ -6,7 +7,7 @@ export default function RootLayout({ children }) {
   return (
     <html lang="en">
       <body className="app-shell">
-        {children}
+        <Providers>{children}</Providers>
       </body>
     </html>
   );

--- a/app/providers.jsx
+++ b/app/providers.jsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { SessionProvider } from "next-auth/react";
+
+export function Providers({ children }) {
+  return <SessionProvider>{children}</SessionProvider>;
+}

--- a/app/rolodex/page.js
+++ b/app/rolodex/page.js
@@ -1,5 +1,6 @@
 "use client";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import AuthButton from "../components/AuthButton";
 import "./rolodex.css";
 
 function IconLoader(props) {
@@ -730,25 +731,28 @@ export default function Rolodex() {
             <h1 id="rolodex-heading">Rolodex</h1>
             <p>Track contacts and follow-ups.</p>
           </div>
-          <button
-            type="button"
-            className={`gmail-button${gmailStatus === "connected" ? " connected" : ""}`}
-            onClick={handleGmailClick}
-            disabled={gmailStatus === "connecting"}
-            aria-busy={gmailStatus === "connecting"}
-          >
-            <span className="icon">
-              {gmailStatus === "connecting" ? (
-                <IconLoader />
-              ) : gmailStatus === "connected" ? (
-                <IconCheck />
-              ) : (
-                <IconMail />
-              )}
-            </span>
-            {gmailLabel}
-            <span className="gmail-tooltip">Use Gmail to auto-log emails.</span>
-          </button>
+          <div className="auth-actions">
+            <AuthButton />
+            <button
+              type="button"
+              className={`gmail-button${gmailStatus === "connected" ? " connected" : ""}`}
+              onClick={handleGmailClick}
+              disabled={gmailStatus === "connecting"}
+              aria-busy={gmailStatus === "connecting"}
+            >
+              <span className="icon">
+                {gmailStatus === "connecting" ? (
+                  <IconLoader />
+                ) : gmailStatus === "connected" ? (
+                  <IconCheck />
+                ) : (
+                  <IconMail />
+                )}
+              </span>
+              {gmailLabel}
+              <span className="gmail-tooltip">Use Gmail to auto-log emails.</span>
+            </button>
+          </div>
         </header>
 
         <div className="context-grid" role="group" aria-label="Contact context">
@@ -828,14 +832,14 @@ export default function Rolodex() {
                   <button
                     type="submit"
                     value="create"
-                  className="button"
-                  disabled={disableSubmit}
-                  aria-busy={loadingAction === "create"}
-                >
-                  {loadingAction === "create" ? <IconLoader /> : null}
-                  {loadingAction === "create" ? "Creating…" : "Create"}
-                </button>
-              </div>
+                    className="button"
+                    disabled={disableSubmit}
+                    aria-busy={loadingAction === "create"}
+                  >
+                    {loadingAction === "create" ? <IconLoader /> : null}
+                    {loadingAction === "create" ? "Creating…" : "Create"}
+                  </button>
+                </div>
               </form>
             </div>
           )}

--- a/app/rolodex/rolodex.css
+++ b/app/rolodex/rolodex.css
@@ -77,6 +77,26 @@
   flex-wrap: wrap;
 }
 
+.auth-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.auth-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  color: var(--text-secondary);
+}
+
+.auth-greeting {
+  margin: 0;
+  font-size: 0.9rem;
+}
+
 .rolodex-heading {
   display: flex;
   flex-direction: column;

--- a/package.json
+++ b/package.json
@@ -9,9 +9,11 @@
   },
   "dependencies": {
     "next": "14.2.5",
+    "next-auth": "^4.24.7",
     "pg": "^8.16.3",
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "googleapis": "^133.0.0"
   },
   "devDependencies": {
     "@types/node": "20.14.12",


### PR DESCRIPTION
## Summary
- configure NextAuth with Google OAuth scopes to persist Gmail access tokens
- add a Gmail send-email API route that uses the signed-in user's tokens
- introduce a session-aware AuthButton and wrap the app with SessionProvider, updating styles for the new header controls

## Testing
- npm install next-auth googleapis *(fails: registry returned 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1f418a6088320a6ac3087edd923f5