### PR TITLE
Add template builder workspace with preview and dry run tools

### DIFF
--- a/app/rolodex/rolodex.css
+++ b/app/rolodex/rolodex.css
@@ -952,6 +952,433 @@ pre.response-view {
   font-size: 0.85rem;
 }
 
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.template-workspace {
+  margin-top: 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+}
+
+.template-workspace h2 {
+  margin: 0;
+  font-size: 1.35rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.template-intro {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+  max-width: 720px;
+}
+
+.template-card {
+  background: rgba(148, 163, 184, 0.14);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 22px;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
+}
+
+html.theme-dark .template-card {
+  background: rgba(30, 41, 59, 0.65);
+  border-color: rgba(71, 85, 105, 0.6);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
+.template-card--builder {
+  gap: 28px;
+}
+
+.template-card--builder .template-builder,
+.template-card--builder .template-context {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+@media (min-width: 980px) {
+  .template-card--builder {
+    display: grid;
+    grid-template-columns: minmax(0, 3fr) minmax(0, 2fr);
+    gap: 32px;
+  }
+}
+
+.template-grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.template-grid .field.double {
+  grid-column: 1 / -1;
+}
+
+.variable-palette {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.palette-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.palette-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.variable-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px;
+  border-radius: 9999px;
+  background: rgba(37, 99, 235, 0.12);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
+}
+
+.variable-chip.special {
+  background: rgba(236, 72, 153, 0.18);
+}
+
+.variable-chip button {
+  border: none;
+  background: transparent;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  cursor: pointer;
+  padding: 6px 10px;
+  border-radius: 9999px;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.variable-chip button:hover,
+.variable-chip button:focus-visible {
+  background: rgba(255, 255, 255, 0.22);
+  outline: none;
+}
+
+.variable-chip .copy-variable {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border-radius: 50%;
+  color: var(--text-secondary);
+}
+
+.variable-chip .copy-variable svg {
+  width: 14px;
+  height: 14px;
+}
+
+.variable-chip .copy-variable:hover,
+.variable-chip .copy-variable:focus-visible {
+  color: var(--text-primary);
+  background: rgba(255, 255, 255, 0.25);
+}
+
+.body-warning {
+  margin-top: 6px;
+  font-size: 0.8rem;
+  color: #dc2626;
+}
+
+html.theme-dark .body-warning {
+  color: #f87171;
+}
+
+.company-facts {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.company-facts-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  color: var(--text-secondary);
+  font-weight: 600;
+}
+
+.company-facts-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.company-fact-item {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+}
+
+.company-fact-item .text-area {
+  flex: 1 1 auto;
+  min-height: 60px;
+}
+
+.contacts-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.contacts-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.contacts-table-wrapper {
+  border: 1px solid var(--card-border);
+  border-radius: 18px;
+  overflow: hidden;
+  overflow-x: auto;
+  background: rgba(15, 23, 42, 0.02);
+}
+
+.contacts-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 540px;
+}
+
+.contacts-table th,
+.contacts-table td {
+  padding: 12px 16px;
+  text-align: left;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.3);
+  color: var(--text-primary);
+  font-size: 0.9rem;
+}
+
+.contacts-table thead th {
+  font-weight: 600;
+  color: var(--text-secondary);
+  background: rgba(37, 99, 235, 0.08);
+}
+
+.contacts-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.template-card--preview {
+  gap: 20px;
+}
+
+.preview-header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.preview-select {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 220px;
+}
+
+.preview-card {
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 18px;
+  padding: 16px;
+  background: rgba(37, 99, 235, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+html.theme-dark .preview-card {
+  background: rgba(37, 99, 235, 0.18);
+}
+
+.preview-line {
+  display: flex;
+  gap: 8px;
+  font-size: 0.9rem;
+  color: var(--text-primary);
+}
+
+.preview-line span {
+  flex: 1 1 auto;
+  word-break: break-word;
+}
+
+.preview-body pre {
+  margin: 8px 0 0;
+  font-family: inherit;
+  font-size: 0.9rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--text-primary);
+}
+
+.dry-run-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.dry-run-results {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.dry-run-summary {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.dry-run-list {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  max-height: 360px;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+
+.dry-run-item {
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 18px;
+  padding: 16px;
+  background: rgba(148, 163, 184, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  transition: opacity 0.15s ease;
+}
+
+html.theme-dark .dry-run-item {
+  background: rgba(30, 41, 59, 0.7);
+}
+
+.dry-run-item.excluded {
+  opacity: 0.6;
+}
+
+.dry-run-item-header {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+@media (min-width: 720px) {
+  .dry-run-item-header {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+}
+
+.dry-run-recipient {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 0.9rem;
+}
+
+.dry-run-item-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.exclude-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.exclude-toggle input {
+  width: 16px;
+  height: 16px;
+}
+
+.dry-run-body {
+  margin: 0;
+  font-size: 0.9rem;
+  background: rgba(255, 255, 255, 0.5);
+  color: var(--text-primary);
+  padding: 12px 14px;
+  border-radius: 12px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+html.theme-dark .dry-run-body {
+  background: rgba(15, 23, 42, 0.9);
+  color: rgba(226, 232, 240, 0.96);
+}
+
+.template-card--send {
+  gap: 12px;
+}
+
+.template-card--send h3 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.template-card--send .helper-text {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+@media (max-width: 640px) {
+  .template-card {
+    padding: 20px;
+  }
+
+  .template-card--builder {
+    gap: 20px;
+  }
+}
+
 @media (max-width: 640px) {
   .toast-stack {
     right: 16px;


### PR DESCRIPTION
## Summary
- add an email template workspace with variable palette, contextual fields, and CSV contact management
- generate previews client-side and trigger n8n dry runs with inline editing and exclusion controls
- style the new workspace sections for template inputs, contacts, previews, and dry run results

## Testing
- npm run lint *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68e5949025d883208aa016b727bfa449