### PR TITLE
Improve rolodex sign-in handling and mobile UI

### DIFF
--- a/app/rolodex/page.js
+++ b/app/rolodex/page.js
@@ -3523,11 +3523,16 @@ function RolodexContent() {
     }
     const wrapperWidth = tabsWrapperRef.current.clientWidth;
     const tabList = tabListRef.current;
-    const collapseBuffer = 88;
-    const expandBuffer = 64;
-    const targetBuffer = areTabsCondensed ? expandBuffer : collapseBuffer;
-    const willWrap = tabList.scrollWidth > wrapperWidth - targetBuffer;
-    setAreTabsCondensed(willWrap);
+    const collapseBuffer = 120;
+    const expandBuffer = 80;
+    const totalTabWidth = tabList.scrollWidth;
+    if (!areTabsCondensed && totalTabWidth > wrapperWidth - collapseBuffer) {
+      setAreTabsCondensed(true);
+      return;
+    }
+    if (areTabsCondensed && totalTabWidth < wrapperWidth - expandBuffer) {
+      setAreTabsCondensed(false);
+    }
   }, [areTabsCondensed]);
 
   const handleTabClick = useCallback(

--- a/app/rolodex/page.js
+++ b/app/rolodex/page.js
@@ -1,7 +1,7 @@
 "use client";
 import { signIn, useSession } from "next-auth/react";
 import { useSearchParams } from "next/navigation";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { CoverLetterWorkspace } from "../cover-letter/workspace";
 import "./rolodex.css";
 
@@ -771,7 +771,7 @@ function IconAlert(props) {
   );
 }
 
-export default function Rolodex() {
+function RolodexContent() {
   const { data: authSession, status: authStatus } = useSession();
   const searchParams = useSearchParams();
   const [username, setUsername] = useState("");
@@ -5577,5 +5577,13 @@ export default function Rolodex() {
         </footer>
       </section>
     </div>
+  );
+}
+
+export default function Rolodex() {
+  return (
+    <Suspense fallback={null}>
+      <RolodexContent />
+    </Suspense>
   );
 }

--- a/app/rolodex/page.js
+++ b/app/rolodex/page.js
@@ -3523,14 +3523,7 @@ function RolodexContent() {
     }
     const wrapperWidth = tabsWrapperRef.current.clientWidth;
     const tabList = tabListRef.current;
-    const firstRowHeight =
-      tabList.firstElementChild?.getBoundingClientRect().height ||
-      tabList.getBoundingClientRect().height ||
-      0;
-    const totalHeight = tabList.getBoundingClientRect().height;
-    const willWrap =
-      tabList.scrollWidth - wrapperWidth > 4 ||
-      (firstRowHeight > 0 && totalHeight - firstRowHeight > 4);
+    const willWrap = tabList.scrollWidth - wrapperWidth > 4;
     setAreTabsCondensed(willWrap);
   }, []);
 

--- a/app/rolodex/page.js
+++ b/app/rolodex/page.js
@@ -1,5 +1,6 @@
 "use client";
 import { signIn, useSession } from "next-auth/react";
+import { useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { CoverLetterWorkspace } from "../cover-letter/workspace";
 import "./rolodex.css";
@@ -772,6 +773,7 @@ function IconAlert(props) {
 
 export default function Rolodex() {
   const { data: authSession, status: authStatus } = useSession();
+  const searchParams = useSearchParams();
   const [username, setUsername] = useState("");
   const [contactId, setContactId] = useState("");
   const [fullName, setFullName] = useState("");
@@ -995,6 +997,19 @@ export default function Rolodex() {
       setToasts((prev) => prev.filter((toast) => toast.id !== id));
     }, TOAST_TIMEOUT);
   }, []);
+
+  useEffect(() => {
+    const errorParam = searchParams?.get("error");
+    if (!errorParam) return;
+
+    pushToast("error", "Sign in error");
+
+    if (typeof window !== "undefined") {
+      const url = new URL(window.location.href);
+      url.searchParams.delete("error");
+      window.history.replaceState(null, document.title, url.toString());
+    }
+  }, [pushToast, searchParams]);
 
   useEffect(() => {
     if (authStatus === "loading") {
@@ -3833,42 +3848,45 @@ export default function Rolodex() {
                   ? "Username is required to view a contact."
                   : "Contacts load automatically on the View and Email tabs."}
               </div>
-            </div>
-
-            <div className="gmail-inline-field">
-              <button
-                type="button"
-                className={`gmail-button${gmailStatus === "connected" ? " connected" : ""}`}
-                onClick={handleGmailClick}
-                disabled={gmailStatus === "connecting"}
-                aria-busy={gmailStatus === "connecting"}
-              >
-                <span className="icon">
-                  {gmailStatus === "connecting" ? (
-                    <IconLoader />
-                  ) : gmailStatus === "connected" ? (
-                    <IconCheck />
-                  ) : (
-                    <IconMail />
-                  )}
-                </span>
-                {gmailLabel}
-                <span className="gmail-tooltip">Use Gmail to auto-log emails.</span>
-              </button>
-            </div>
-
-            <div className="theme-inline-field">
-              <button
-                type="button"
-                className="theme-toggle"
-                onClick={toggleTheme}
-                aria-label={themeToggleLabel}
-              >
-                {theme === "dark" ? <IconSun /> : <IconMoon />}
-                <span>{theme === "dark" ? "Light" : "Dark"}</span>
-              </button>
-            </div>
           </div>
+
+          <div className="gmail-inline-field">
+            <button
+              type="button"
+              className={`gmail-button${gmailStatus === "connected" ? " connected" : ""}`}
+              onClick={handleGmailClick}
+              disabled={gmailStatus === "connecting"}
+              aria-busy={gmailStatus === "connecting"}
+              aria-label={gmailLabel}
+            >
+              <span className="icon">
+                {gmailStatus === "connecting" ? (
+                  <IconLoader />
+                ) : gmailStatus === "connected" ? (
+                  <IconCheck />
+                ) : (
+                  <IconMail />
+                )}
+              </span>
+              <span className="gmail-label">{gmailLabel}</span>
+              <span className="gmail-tooltip">Use Gmail to auto-log emails.</span>
+            </button>
+          </div>
+
+          <div className="theme-inline-field">
+            <button
+              type="button"
+              className="theme-toggle"
+              onClick={toggleTheme}
+              aria-label={themeToggleLabel}
+            >
+              {theme === "dark" ? <IconSun /> : <IconMoon />}
+              <span className="theme-label">
+                {theme === "dark" ? "Light" : "Dark"}
+              </span>
+            </button>
+          </div>
+        </div>
         <div
           className={`rolodex-tabs-wrapper${isMobileTabsOpen ? " open" : ""}`}
         >

--- a/app/rolodex/page.js
+++ b/app/rolodex/page.js
@@ -3523,7 +3523,8 @@ function RolodexContent() {
     }
     const wrapperWidth = tabsWrapperRef.current.clientWidth;
     const tabList = tabListRef.current;
-    const willWrap = tabList.scrollWidth - wrapperWidth > 4;
+    const buffer = 28;
+    const willWrap = tabList.scrollWidth > wrapperWidth - buffer;
     setAreTabsCondensed(willWrap);
   }, []);
 

--- a/app/rolodex/page.js
+++ b/app/rolodex/page.js
@@ -3523,10 +3523,12 @@ function RolodexContent() {
     }
     const wrapperWidth = tabsWrapperRef.current.clientWidth;
     const tabList = tabListRef.current;
-    const buffer = 28;
-    const willWrap = tabList.scrollWidth > wrapperWidth - buffer;
+    const collapseBuffer = 88;
+    const expandBuffer = 64;
+    const targetBuffer = areTabsCondensed ? expandBuffer : collapseBuffer;
+    const willWrap = tabList.scrollWidth > wrapperWidth - targetBuffer;
     setAreTabsCondensed(willWrap);
-  }, []);
+  }, [areTabsCondensed]);
 
   const handleTabClick = useCallback(
     (tabId) => {

--- a/app/rolodex/rolodex.css
+++ b/app/rolodex/rolodex.css
@@ -331,52 +331,33 @@ html.theme-dark {
 
 .context-primary-row {
   display: flex;
-  flex-wrap: nowrap;
-  align-items: center;
+  flex-wrap: wrap;
+  align-items: stretch;
   justify-content: flex-start;
-  gap: 14px 16px;
+  gap: 12px 16px;
 }
 
-.context-primary-row .gmail-inline-field,
-.context-primary-row .theme-inline-field {
+.context-primary-row .rolodex-tabs-wrapper {
+  flex: 1 1 320px;
+  min-width: 240px;
+}
+
+.context-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-left: auto;
+}
+
+.context-actions .gmail-inline-field,
+.context-actions .theme-inline-field {
   display: flex;
   align-items: center;
   justify-content: center;
   flex: 0 0 auto;
 }
 
-.context-primary-row .username-field {
-  flex: 1 1 320px;
-  min-width: 220px;
-  order: 0;
-  min-height: auto;
-  position: relative;
-  gap: 0;
-  padding-bottom: calc(var(--field-helper-height) + 6px);
-}
-
-.context-primary-row .gmail-inline-field {
-  order: 1;
-  margin-left: auto;
-  justify-content: flex-end;
-}
-
-.context-primary-row .theme-inline-field {
-  order: 2;
-}
-
-.context-primary-row .username-field .field-input-row {
-  align-items: center;
-}
-
-.context-primary-row .username-field .helper-text {
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  width: 100%;
-}
-
-.context-primary-row .gmail-inline-field .gmail-button {
+.context-actions .gmail-inline-field .gmail-button {
   flex-shrink: 0;
 }
 
@@ -386,33 +367,17 @@ html.theme-dark {
 
 @media (max-width: 768px) {
   .context-primary-row {
-    flex-wrap: wrap;
-    justify-content: space-between;
-    gap: 12px;
+    gap: 10px 12px;
   }
 
-  .context-primary-row .theme-inline-field,
-  .context-primary-row .gmail-inline-field {
-    flex: 1 1 calc(50% - 6px);
+  .context-primary-row .rolodex-tabs-wrapper {
+    flex: 1 1 100%;
     min-width: 0;
   }
 
-  .context-primary-row .theme-inline-field {
-    order: 0;
-    justify-content: flex-start;
-    margin-left: 0;
-  }
-
-  .context-primary-row .gmail-inline-field {
-    order: 1;
+  .context-actions {
+    flex: 1 1 100%;
     justify-content: flex-end;
-    margin-left: 0;
-  }
-
-  .context-primary-row .username-field {
-    flex: 0 0 100%;
-    min-width: 0;
-    order: 2;
   }
 }
 
@@ -424,6 +389,14 @@ html.theme-dark {
 
 .field-input-row .text-input {
   flex: 1 1 auto;
+}
+
+.rolodex-tabs-wrapper,
+.tab-menu-toggle,
+.tab-button,
+.theme-toggle,
+.gmail-button {
+  min-height: 44px;
 }
 
 .visually-hidden {

--- a/app/rolodex/rolodex.css
+++ b/app/rolodex/rolodex.css
@@ -275,6 +275,10 @@ html.theme-dark {
   justify-content: center;
 }
 
+.gmail-label {
+  white-space: nowrap;
+}
+
 .gmail-tooltip {
   position: absolute;
   top: 100%;
@@ -439,6 +443,7 @@ html.theme-dark {
   align-items: center;
   gap: 12px;
   position: relative;
+  z-index: 1;
 }
 
 .tab-menu-toggle {
@@ -541,8 +546,12 @@ html.theme-dark {
     padding: 8px;
     box-shadow: var(--shadow-sm);
     display: none;
-    z-index: 10;
+    z-index: 20;
     min-width: 200px;
+  }
+
+  .rolodex-tabs-wrapper {
+    z-index: 15;
   }
 
   .rolodex-tabs-wrapper.open .rolodex-tabs {
@@ -552,6 +561,27 @@ html.theme-dark {
   .tab-button {
     width: 100%;
     justify-content: flex-start;
+  }
+}
+
+@media (max-aspect-ratio: 3/4) {
+  .theme-toggle {
+    padding: 8px;
+    justify-content: center;
+  }
+
+  .theme-toggle .theme-label {
+    display: none;
+  }
+
+  .gmail-button {
+    padding: 10px;
+    gap: 8px;
+  }
+
+  .gmail-button .gmail-label,
+  .gmail-button .gmail-tooltip {
+    display: none;
   }
 }
 

--- a/app/rolodex/rolodex.css
+++ b/app/rolodex/rolodex.css
@@ -419,6 +419,10 @@ html.theme-dark {
   z-index: 1;
 }
 
+.rolodex-tabs-wrapper.condensed {
+  align-items: stretch;
+}
+
 .tab-menu-toggle {
   display: none;
   align-items: center;
@@ -464,6 +468,44 @@ html.theme-dark {
   flex: 1 1 auto;
   flex-wrap: wrap;
   gap: 8px;
+}
+
+.rolodex-tabs-wrapper.condensed .tab-menu-toggle {
+  display: inline-flex;
+}
+
+.rolodex-tabs-wrapper.condensed .rolodex-tabs {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  flex-direction: column;
+  flex-wrap: nowrap;
+  gap: 6px;
+  background: var(--card-background);
+  border: 1px solid var(--card-border);
+  border-radius: 16px;
+  padding: 8px;
+  box-shadow: var(--shadow-sm);
+  min-width: 200px;
+  max-width: min(480px, 90vw);
+  visibility: hidden;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(4px);
+  transition: opacity 0.12s ease, transform 0.12s ease;
+  z-index: 20;
+}
+
+.rolodex-tabs-wrapper.condensed.open .rolodex-tabs {
+  visibility: visible;
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(0);
+}
+
+.rolodex-tabs-wrapper.condensed .tab-button {
+  width: 100%;
+  justify-content: flex-start;
 }
 
 .tab-button {
@@ -512,15 +554,21 @@ html.theme-dark {
     top: calc(100% + 6px);
     left: 0;
     flex-direction: column;
+    flex-wrap: nowrap;
     gap: 6px;
     background: var(--card-background);
     border: 1px solid var(--card-border);
     border-radius: 16px;
     padding: 8px;
     box-shadow: var(--shadow-sm);
-    display: none;
-    z-index: 20;
     min-width: 200px;
+    max-width: min(480px, 90vw);
+    visibility: hidden;
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(4px);
+    transition: opacity 0.12s ease, transform 0.12s ease;
+    z-index: 20;
   }
 
   .rolodex-tabs-wrapper {
@@ -528,7 +576,10 @@ html.theme-dark {
   }
 
   .rolodex-tabs-wrapper.open .rolodex-tabs {
-    display: flex;
+    visibility: visible;
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0);
   }
 
   .tab-button {

--- a/app/rolodex/rolodex.css
+++ b/app/rolodex/rolodex.css
@@ -466,7 +466,7 @@ html.theme-dark {
 .rolodex-tabs {
   display: flex;
   flex: 1 1 auto;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   gap: 8px;
 }
 

--- a/app/rolodex/rolodex.css
+++ b/app/rolodex/rolodex.css
@@ -340,7 +340,8 @@ html.theme-dark {
 .context-primary-row .rolodex-tabs-wrapper {
   flex: 1 1 320px;
   min-width: 240px;
-  padding-right: 8px;
+  padding-right: 56px;
+  align-self: center;
 }
 
 .context-actions {
@@ -374,6 +375,7 @@ html.theme-dark {
   .context-primary-row .rolodex-tabs-wrapper {
     flex: 1 1 100%;
     min-width: 0;
+    padding-right: 16px;
   }
 
   .context-actions {

--- a/app/rolodex/rolodex.css
+++ b/app/rolodex/rolodex.css
@@ -332,7 +332,7 @@ html.theme-dark {
 .context-primary-row {
   display: flex;
   flex-wrap: wrap;
-  align-items: stretch;
+  align-items: center;
   justify-content: flex-start;
   gap: 12px 16px;
 }
@@ -340,6 +340,7 @@ html.theme-dark {
 .context-primary-row .rolodex-tabs-wrapper {
   flex: 1 1 320px;
   min-width: 240px;
+  padding-right: 8px;
 }
 
 .context-actions {
@@ -399,6 +400,13 @@ html.theme-dark {
   min-height: 44px;
 }
 
+.tab-menu-toggle,
+.tab-button,
+.theme-toggle,
+.gmail-button {
+  align-self: center;
+}
+
 .visually-hidden {
   position: absolute;
   width: 1px;
@@ -420,7 +428,7 @@ html.theme-dark {
 }
 
 .rolodex-tabs-wrapper.condensed {
-  align-items: stretch;
+  align-items: center;
 }
 
 .tab-menu-toggle {

--- a/app/rolodex/rolodex.css
+++ b/app/rolodex/rolodex.css
@@ -400,6 +400,7 @@ html.theme-dark {
 .theme-toggle,
 .gmail-button {
   min-height: 44px;
+  height: 44px;
 }
 
 .tab-menu-toggle,

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -22,6 +22,9 @@ export const authOptions: NextAuthOptions = {
       },
     }),
   ],
+  pages: {
+    error: "/rolodex",
+  },
   callbacks: {
   async jwt({ token, account }) {
     if (account) {


### PR DESCRIPTION
## Summary
- redirect NextAuth errors back to the rolodex page and surface a sign-in error toast
- streamline the Gmail connect and theme toggle buttons for very small aspect ratios
- raise the mobile tab dropdown above surrounding inputs so it remains visible

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ff8f0080483209bb5e36921499f24)