### PR TITLE
Improve rolodex tabs and add view export

### DIFF
--- a/app/rolodex/page.js
+++ b/app/rolodex/page.js
@@ -3563,6 +3563,7 @@ export default function Rolodex() {
 
     const resizeObserver = new ResizeObserver(checkWrap);
     resizeObserver.observe(tabList);
+    resizeObserver.observe(wrapper);
     window.addEventListener("resize", checkWrap);
 
     checkWrap();

--- a/app/rolodex/page.js
+++ b/app/rolodex/page.js
@@ -146,35 +146,6 @@ function IconMenu(props) {
   );
 }
 
-function IconGoogle(props) {
-  return (
-    <svg
-      aria-hidden="true"
-      viewBox="0 0 48 48"
-      className={props.className}
-      role="img"
-      focusable="false"
-    >
-      <path
-        fill="#EA4335"
-        d="M24 9.5c3.94 0 6.6 1.7 8.12 3.13l5.9-5.74C34.92 3.25 29.92 1 24 1 14.74 1 6.9 6.16 3.24 14.02l6.9 5.35C11.6 13.4 17.2 9.5 24 9.5z"
-      />
-      <path
-        fill="#4285F4"
-        d="M46.5 24.5c0-1.56-.14-3.06-.4-4.5H24v8.51h12.65c-.55 2.82-2.22 5.2-4.72 6.8l7.25 5.63C43.79 36.9 46.5 31.3 46.5 24.5z"
-      />
-      <path
-        fill="#FBBC05"
-        d="M24 47c6.48 0 11.9-2.13 15.87-5.8l-7.25-5.63C30.7 37.8 27.59 38.5 24 38.5c-6.8 0-12.41-3.9-15.86-9.35l-6.9 7.34C6.9 41.84 14.74 47 24 47z"
-      />
-      <path
-        fill="#34A853"
-        d="M10.14 28.86c-1.08-3.2-1.08-6.5 0-9.7L3.24 13.8C-.47 20.64-.47 29.36 3.24 36.2l6.9-7.34z"
-      />
-    </svg>
-  );
-}
-
 const TOAST_TIMEOUT = 4500;
 
 const EMAIL_REGEX = /.+@.+\..+/;
@@ -3564,9 +3535,16 @@ export default function Rolodex() {
 
     const checkWrap = () => {
       const previousDisplay = tabList.style.display;
-      if (tabList.classList.contains("compact")) {
-        tabList.style.display = "flex";
+      const previousFlexWrap = tabList.style.flexWrap;
+      const wasCompactClass = tabList.classList.contains("compact");
+
+      if (wasCompactClass) {
+        tabList.classList.remove("compact");
       }
+
+      tabList.style.display = "flex";
+      tabList.style.flexWrap = "wrap";
+
       const firstTab = tabList.querySelector(".tab-button");
       const rowHeight = firstTab?.getBoundingClientRect().height || 0;
       const listHeight = tabList.getBoundingClientRect().height;
@@ -3574,7 +3552,13 @@ export default function Rolodex() {
         listHeight > (rowHeight || listHeight) * 1.2 ||
         tabList.scrollWidth > tabList.clientWidth + 1;
       setIsCompactTabs(hasWrap);
+
+      tabList.style.flexWrap = previousFlexWrap;
       tabList.style.display = previousDisplay;
+
+      if (wasCompactClass) {
+        tabList.classList.add("compact");
+      }
     };
 
     const resizeObserver = new ResizeObserver(checkWrap);
@@ -4065,7 +4049,7 @@ export default function Rolodex() {
                 aria-label={gmailLabel}
               >
                 <span className="gmail-icon" aria-hidden="true">
-                  <IconGoogle className="gmail-google" />
+                  <IconMail className="gmail-mail" />
                   {gmailStatus === "connecting" ? (
                     <IconLoader className="loader gmail-status" />
                   ) : gmailStatus === "connected" ? (

--- a/app/rolodex/rolodex.css
+++ b/app/rolodex/rolodex.css
@@ -287,9 +287,9 @@ html.theme-dark {
   height: 22px;
 }
 
-.gmail-google {
-  width: 100%;
-  height: 100%;
+.gmail-mail {
+  width: 18px;
+  height: 18px;
 }
 
 .gmail-status {
@@ -405,7 +405,7 @@ html.theme-dark {
   padding-bottom: 4px;
   scrollbar-width: none;
   position: relative;
-  z-index: 6;
+  z-index: 20;
 }
 
 .context-toolbar::-webkit-scrollbar {
@@ -416,7 +416,7 @@ html.theme-dark {
   flex: 1 1 auto;
   min-width: 0;
   position: relative;
-  z-index: 2;
+  z-index: 40;
 }
 
 .context-controls {
@@ -474,6 +474,7 @@ html.theme-dark {
   align-items: center;
   gap: 12px;
   position: relative;
+  z-index: 1;
 }
 
 .rolodex-tabs-wrapper.compact {
@@ -543,7 +544,7 @@ html.theme-dark {
   padding: 8px;
   box-shadow: var(--shadow-sm);
   display: none;
-  z-index: 120;
+  z-index: 240;
   min-width: 220px;
 }
 
@@ -621,7 +622,7 @@ html.theme-dark {
     padding: 8px;
     box-shadow: var(--shadow-sm);
     display: none;
-    z-index: 120;
+    z-index: 240;
     min-width: 200px;
   }
 

--- a/app/rolodex/rolodex.css
+++ b/app/rolodex/rolodex.css
@@ -342,6 +342,13 @@ html.theme-dark {
   }
 }
 
+@media (max-width: 900px) {
+  .gmail-label,
+  .theme-label {
+    display: none !important;
+  }
+}
+
 .gmail-tooltip {
   position: absolute;
   top: 100%;
@@ -469,6 +476,10 @@ html.theme-dark {
   position: relative;
 }
 
+.rolodex-tabs-wrapper.compact {
+  align-items: stretch;
+}
+
 .tab-menu-toggle {
   display: none;
   align-items: center;
@@ -520,6 +531,26 @@ html.theme-dark {
   gap: 8px;
 }
 
+.rolodex-tabs.compact {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  flex-direction: column;
+  gap: 6px;
+  background: var(--card-background);
+  border: 1px solid var(--card-border);
+  border-radius: 16px;
+  padding: 8px;
+  box-shadow: var(--shadow-sm);
+  display: none;
+  z-index: 120;
+  min-width: 220px;
+}
+
+.rolodex-tabs.compact.open {
+  display: flex;
+}
+
 .tab-button {
   display: inline-flex;
   align-items: center;
@@ -552,6 +583,23 @@ html.theme-dark {
   color: var(--text-primary);
 }
 
+.rolodex-tabs-wrapper.compact .tab-menu-toggle {
+  display: inline-flex;
+}
+
+.rolodex-tabs-wrapper.compact .rolodex-tabs {
+  display: none;
+}
+
+.rolodex-tabs-wrapper.compact .rolodex-tabs.open {
+  display: flex;
+}
+
+.rolodex-tabs-wrapper.compact .tab-button {
+  width: 100%;
+  justify-content: flex-start;
+}
+
 @media (max-width: 768px) {
   .rolodex-tabs-wrapper {
     align-items: stretch;
@@ -573,7 +621,7 @@ html.theme-dark {
     padding: 8px;
     box-shadow: var(--shadow-sm);
     display: none;
-    z-index: 50;
+    z-index: 120;
     min-width: 200px;
   }
 
@@ -886,6 +934,45 @@ html.theme-dark {
 .table-refresh-button .loader {
   width: 18px;
   height: 18px;
+}
+
+.table-export-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 9px 14px;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  background: transparent;
+  color: var(--text-secondary);
+  font-weight: 700;
+  cursor: pointer;
+  transition:
+    background 0.15s ease,
+    color 0.15s ease,
+    border-color 0.15s ease;
+}
+
+.table-export-button:hover,
+.table-export-button:focus-visible {
+  background: rgba(37, 99, 235, 0.08);
+  border-color: rgba(37, 99, 235, 0.45);
+  color: var(--text-primary);
+  outline: none;
+}
+
+.table-export-button:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.table-export-button svg {
+  width: 18px;
+  height: 18px;
+}
+
+.export-label {
+  white-space: nowrap;
 }
 
 .table-search {

--- a/app/rolodex/rolodex.css
+++ b/app/rolodex/rolodex.css
@@ -379,6 +379,8 @@ html.theme-dark {
   display: flex;
   flex-direction: column;
   gap: 14px;
+  position: relative;
+  z-index: 0;
 }
 
 .rolodex-form-grid {
@@ -530,6 +532,8 @@ html.theme-dark {
   flex: 1 1 auto;
   flex-wrap: wrap;
   gap: 8px;
+  position: relative;
+  z-index: 10000;
 }
 
 .rolodex-tabs.compact {
@@ -544,7 +548,7 @@ html.theme-dark {
   padding: 8px;
   box-shadow: var(--shadow-sm);
   display: none;
-  z-index: 240;
+  z-index: 10000;
   min-width: 220px;
 }
 
@@ -622,7 +626,7 @@ html.theme-dark {
     padding: 8px;
     box-shadow: var(--shadow-sm);
     display: none;
-    z-index: 240;
+    z-index: 10000;
     min-width: 200px;
   }
 

--- a/app/rolodex/rolodex.css
+++ b/app/rolodex/rolodex.css
@@ -405,7 +405,7 @@ html.theme-dark {
   padding-bottom: 4px;
   scrollbar-width: none;
   position: relative;
-  z-index: 20;
+  z-index: 9999;
 }
 
 .context-toolbar::-webkit-scrollbar {
@@ -416,7 +416,7 @@ html.theme-dark {
   flex: 1 1 auto;
   min-width: 0;
   position: relative;
-  z-index: 40;
+  z-index: 9999;
 }
 
 .context-controls {


### PR DESCRIPTION
## Summary
- switch rolodex tabs to a compact dropdown before wrapping and raise its stacking order so it stays visible
- hide theme and Gmail button text on narrower screens to preserve space
- add an XLS export action to the View tab with guard rails when no contacts are loaded

## Testing
- npm run lint *(fails: Missing script "lint")*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69221b9b87e08320927f458fc4778d97)