### PR TITLE
Increase rolodex tablist z-index

### DIFF
--- a/app/rolodex/rolodex.css
+++ b/app/rolodex/rolodex.css
@@ -541,7 +541,7 @@ html.theme-dark {
     padding: 8px;
     box-shadow: var(--shadow-sm);
     display: none;
-    z-index: 10;
+    z-index: 2147483647;
     min-width: 200px;
   }
 
@@ -1797,7 +1797,7 @@ html.theme-dark {
   display: flex;
   flex-direction: column;
   gap: 12px;
-  z-index: 9999;
+  z-index: 9000;
 }
 
 .toast {


### PR DESCRIPTION
## Summary
- raise the rolodex tablist dropdown z-index so it appears above all other elements
- lower toast stack layering to reduce potential overlap issues

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e3edadba083209b37cd3ee43c3bae)